### PR TITLE
fix: allow missing migration due to version conflict

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -66,7 +66,7 @@ migrate-up:
 	@echo "Applying migrations to $(APP_ENVIRONMENT) database..."
 	@doppler run --project backend --config $(APP_ENVIRONMENT) -- sh -c '\
 		HOST=$$( [ "$(APP_ENVIRONMENT)" = "dev" ] && echo localhost || echo $$DB_HOST ); \
-		goose -dir $(MIGRATIONS_DIR) postgres "postgres://$$DB_USER:$$DB_PASSWORD@$$HOST:$$DB_PORT/$$DB_DATABASE?sslmode=disable" up \
+		goose -allow-missing -dir $(MIGRATIONS_DIR) postgres "postgres://$$DB_USER:$$DB_PASSWORD@$$HOST:$$DB_PORT/$$DB_DATABASE?sslmode=disable" up \
 	'
 
 migrate-up-win:
@@ -75,7 +75,7 @@ migrate-up-win:
 		$$dbHost = if ('$(APP_ENVIRONMENT)' -eq 'dev') { 'localhost' } else { $$env:DB_HOST }; \
 		$$connectionString = \"postgres://$${env:DB_USER}:$${env:DB_PASSWORD}@$${dbHost}:$${env:DB_PORT}/$${env:DB_DATABASE}?sslmode=disable\"; \
 		Write-Host 'Applying migrations to $(APP_ENVIRONMENT) database...'; \
-		goose -dir $(MIGRATIONS_DIR) postgres $$connectionString up"
+		goose -allow-missing -dir $(MIGRATIONS_DIR) postgres $$connectionString up"
 
 migrate-down:
 	@echo "Rolling back last migration on $(APP_ENVIRONMENT) database..."

--- a/backend/internal/database/migration.go
+++ b/backend/internal/database/migration.go
@@ -24,7 +24,7 @@ func ApplyGooseMigrations(ctx context.Context, host string, port int, user, pass
 		}
 	}()
 
-	if err := goose.Up(sqlDB, "../migrations"); err != nil {
+	if err := goose.Up(sqlDB, "../migrations", goose.WithAllowMissing()); err != nil {
 		log.Printf("failed to apply migrations: %v", err)
 		return err
 	}


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Database migrations now tolerate missing migration files without failing, enabling continuation when version conflicts occur
- Makefile migrate-up targets (Unix and Windows variants) updated with `-allow-missing` flag
- Go database migration function now passes `WithAllowMissing()` option to goose.Up()

## Changes by Category

**Fixes**
- Allow missing migrations due to version conflicts in both Makefile and migration.go

**Infra**
- Update migration tooling configuration to handle incomplete migration sets

## Author Contribution

| Metric | Count |
|--------|-------|
| Added lines | 2 |
| Removed lines | 2 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->