### PR TITLE
remove redis from docker compose prod

### DIFF
--- a/backend/docker-compose.prod.yml
+++ b/backend/docker-compose.prod.yml
@@ -1,19 +1,6 @@
 version: "3.9"
 
 services:
-  redis:
-    image: redis:8-alpine
-    container_name: redis
-    restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD}
-    networks:
-      - backend_network
-    healthcheck:
-      test: ["CMD", "redis-cli", "--pass", "${REDIS_PASSWORD}", "ping"]
-      interval: 3s
-      timeout: 3s
-      retries: 10
-
   api:
     build:
       context: .
@@ -21,13 +8,8 @@ services:
     environment:
       DOPPLER_TOKEN: ${DOPPLER_TOKEN}
       APP_PORT: 8000
-      REDIS_ADDRESS: ${REDIS_ADDRESS}
-      REDIS_PASSWORD: ${REDIS_PASSWORD}
     ports:
       - "8000:8000"
-    depends_on:
-      redis:
-        condition: service_healthy
     networks:
       - backend_network
 


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Removed Redis service from production Docker Compose configuration, eliminating Redis as a required dependency for production deployments
- API service in production no longer requires Redis connection credentials or waits for Redis service to become healthy
- Production environment now only depends on PostgreSQL database service

## Changes by Category

**Infrastructure:**
- Removed Redis service definition from docker-compose.prod.yml (image, container name, restart policy, command, networks, and healthcheck configuration)
- Removed REDIS_ADDRESS and REDIS_PASSWORD environment variables from API service
- Removed Redis dependency check from API service (service_healthy condition)

## Contribution Summary

| Metric | Count |
|--------|-------|
| Lines Added | 0 |
| Lines Removed | 18 |
| Net Change | -18 |

**Note:** Changes are scoped to production configuration only. Development (docker-compose.yml) and test (docker-compose.test.yml) environments retain Redis service for local and testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->