### PR TITLE
feat: simple skeleton shapes for loading state

### DIFF
--- a/frontend/design-system/components/skeleton/circle.tsx
+++ b/frontend/design-system/components/skeleton/circle.tsx
@@ -1,0 +1,28 @@
+import { CoreSizeKey } from "@/design-system/tokens/core-size";
+import { StyleSheet, ViewStyle } from "react-native";
+import SkeletonRect from "./rectangle";
+
+type SkeletonVariant = "light" | "base" | "dark";
+
+interface SkeletonCircleProps {
+  size?: CoreSizeKey;
+  variant?: SkeletonVariant;
+  style?: ViewStyle;
+}
+
+const SkeletonCircle = ({
+  size = "xl",
+  variant = "base",
+  style,
+}: SkeletonCircleProps) => {
+  return (
+    <SkeletonRect
+      size={size}
+      variant={variant}
+      borderRadius="full"
+      style={StyleSheet.flatten([{ overflow: "hidden" }, style])}
+    />
+  );
+};
+
+export default SkeletonCircle;

--- a/frontend/design-system/components/skeleton/rectangle.tsx
+++ b/frontend/design-system/components/skeleton/rectangle.tsx
@@ -1,0 +1,86 @@
+import { AnimatedBox } from "@/design-system/primitives/animated-box";
+import { CoreSize, CoreSizeKey } from "@/design-system/tokens/core-size";
+import {
+  CornerRadius,
+  CornerRadiusKey,
+} from "@/design-system/tokens/corner-radius";
+import usePulsingAnimation from "@/hooks/animation";
+import { ViewStyle } from "react-native";
+
+export const SkeletonWidth = {
+  quarter: "25%",
+  half: "50%",
+  threeQuarter: "75%",
+  full: "100%",
+} as const;
+
+const SkeletonVariantOpacity = {
+  light: 0.4,
+  base: 0.7,
+  dark: 1,
+} as const;
+
+type SkeletonVariant = keyof typeof SkeletonVariantOpacity;
+type SkeletonWidthKey = keyof typeof SkeletonWidth;
+
+type SquareMode = {
+  size: CoreSizeKey;
+  borderRadius?: CornerRadiusKey;
+  width?: never;
+  height?: never;
+};
+
+type RectMode = {
+  size?: never;
+  borderRadius?: CornerRadiusKey;
+  width?: SkeletonWidthKey;
+  height?: CoreSizeKey;
+};
+
+type SkeletonRectProps = (SquareMode | RectMode) & {
+  variant?: SkeletonVariant;
+  style?: ViewStyle;
+};
+
+const getAutoRadius = (height: number): CornerRadiusKey => {
+  if (height <= CoreSize.xs) return "xs";
+  if (height <= CoreSize.md) return "sm";
+  if (height <= CoreSize.lg) return "md";
+  return "lg";
+};
+
+const SkeletonRect = ({
+  size,
+  borderRadius,
+  variant = "base",
+  width = "full",
+  height = "xs",
+  style,
+}: SkeletonRectProps) => {
+  const opacity = usePulsingAnimation(SkeletonVariantOpacity[variant]);
+
+  const resolvedSize = size ? CoreSize[size] : undefined;
+  const resolvedHeight = resolvedSize ?? CoreSize[height];
+  const resolvedWidth = resolvedSize ?? SkeletonWidth[width];
+
+  const defaultRadius = resolvedSize ? "sm" : getAutoRadius(resolvedHeight);
+  const resolvedRadius = CornerRadius[borderRadius ?? defaultRadius];
+
+  return (
+    <AnimatedBox
+      style={[
+        {
+          width: resolvedWidth,
+          height: resolvedHeight,
+          borderRadius: resolvedRadius,
+          overflow: "hidden",
+          opacity,
+        },
+        style,
+      ]}
+      backgroundColor="secondaryBackground"
+    />
+  );
+};
+
+export default SkeletonRect;

--- a/frontend/design-system/components/ui-kit-display/display.tsx
+++ b/frontend/design-system/components/ui-kit-display/display.tsx
@@ -19,6 +19,8 @@ import {
 import { ArrowRight, Mail, Star } from "lucide-react-native";
 import { useMemo, useState } from "react";
 import { Animated, Easing, TouchableOpacity } from "react-native";
+import SkeletonCircle from "../skeleton/circle";
+import SkeletonRect from "../skeleton/rectangle";
 
 function Section({
   title,
@@ -110,6 +112,21 @@ export default function UIKit() {
           Subjected to change.
         </Text>
       </Box>
+
+      <Section title="Skeleton">
+        <Text variant="xsLabel" color="textSecondary">
+          shapes
+        </Text>
+        <Row label="rect">
+          <SkeletonRect width="half" height="md" />
+        </Row>
+        <Row label="square">
+          <SkeletonRect size="xl" />
+        </Row>
+        <Row label="circle">
+          <SkeletonCircle size="xl" />
+        </Row>
+      </Section>
 
       <Section title="Color">
         {(Object.keys(ColorPalette) as ColorName[]).map((key) => (

--- a/frontend/design-system/index.ts
+++ b/frontend/design-system/index.ts
@@ -26,3 +26,7 @@ export { BackButton } from "./components/navigation/arrow";
 
 // ─── UI Kit Display (for testing/showcasing components) ──────────────────────────────
 export { default as UIKitDisplay } from "./components/ui-kit-display/display";
+
+// ─── Skeletons ──────────────────────────────────────────────────────────────────────
+export { default as SkeletonCircle } from "./components/skeleton/circle";
+export { default as SkeletonRect } from "./components/skeleton/rectangle";


### PR DESCRIPTION
# Description
- Add circle and rectangle with pulsing animation
- These components can be used to create skeleton for loading state throughout the app

## How has this been tested?

https://github.com/user-attachments/assets/61ce336f-2e5b-4431-b06f-6e5dd4974067

## Checklist

* [x]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [x] New and existing tests pass locally with my changes.
* [x] I have followed the project's coding standards and best practices.