### PR TITLE
fix: time cursor parsing time

### DIFF
--- a/backend/internal/controllers/activity.go
+++ b/backend/internal/controllers/activity.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"encoding/base64"
 	"errors"
 	"net/http"
 	"toggo/internal/errs"
@@ -543,12 +542,6 @@ func (ctrl *ActivityController) parseRSVPPaginationRequest(
 	}
 
 	limit, cursor := utilities.ExtractLimitAndCursor(&pagination)
-
-	if cursor != "" {
-		if _, err := base64.StdEncoding.DecodeString(cursor); err != nil {
-			return nil, errs.BadRequest(errors.New("invalid cursor format"))
-		}
-	}
 
 	status := c.Query("status")
 	if status != "" {

--- a/backend/internal/services/activity.go
+++ b/backend/internal/services/activity.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"time"
 	"toggo/internal/errs"
 	"toggo/internal/models"
@@ -422,7 +423,7 @@ func (s *ActivityService) GetActivityRSVPs(
 
 	cursor, err := pagination.DecodeTimeCursor(cursorToken)
 	if err != nil {
-		return nil, err
+		return nil, errs.BadRequest(errors.New("invalid cursor format"))
 	}
 
 	rsvps, lastCreatedAt, err := s.ActivityRSVP.GetActivityRSVPs(

--- a/backend/internal/tests/mocks/mock_S3PresignClient.go
+++ b/backend/internal/tests/mocks/mock_S3PresignClient.go
@@ -7,7 +7,7 @@ package mocks
 import (
 	"context"
 
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	mock "github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Fixed time cursor parsing errors in RSVP pagination by removing overly strict Base64 format validation that rejected valid time cursors
- Improved error messages returned to clients from raw decode errors to a clear "invalid cursor format" message
- GetActivityRSVPs endpoint now properly handles and reports cursor validation failures

## Changes by Category

**Fixes**
- Removed Base64 validation check in activity controller that was rejecting valid time-based cursor formats
- Enhanced error handling in GetActivityRSVPs service method to return wrapped errors with descriptive messages instead of raw decode failures

**Infra**
- Removed explicit import alias for AWS SDK v4 signer package in mock S3 client

## Author Contribution

| File | Added | Removed |
|------|-------|---------|
| backend/internal/controllers/activity.go | 0 | 7 |
| backend/internal/services/activity.go | 2 | 1 |
| backend/internal/tests/mocks/mock_S3PresignClient.go | 1 | 1 |
| **Total** | **3** | **9** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->