### PR TITLE
feat: set up universal links

### DIFF
--- a/backend/internal/config/app.go
+++ b/backend/internal/config/app.go
@@ -9,9 +9,13 @@ import (
 )
 
 type AppConfig struct {
-	Name    string `validate:"required"`
-	Version string `validate:"required"`
-	Port    int    `validate:"required,gt=0"`
+	Name            string `validate:"required"`
+	Version         string `validate:"required"`
+	Port            int    `validate:"required,gt=0"`
+	PublicURL       string
+	DeepLinkBaseURL string
+	AppleTeamID     string
+	IOSBundleID     string
 }
 
 func LoadAppConfig() (*AppConfig, error) {
@@ -22,9 +26,13 @@ func LoadAppConfig() (*AppConfig, error) {
 	}
 
 	cfg := &AppConfig{
-		Name:    os.Getenv("APP_NAME"),
-		Version: os.Getenv("APP_VERSION"),
-		Port:    port,
+		Name:            os.Getenv("APP_NAME"),
+		Version:         os.Getenv("APP_VERSION"),
+		Port:            port,
+		PublicURL:       os.Getenv("APP_PUBLIC_URL"),
+		DeepLinkBaseURL: os.Getenv("DEEPLINK_BASE_URL"),
+		AppleTeamID:     os.Getenv("APPLE_TEAM_ID"),
+		IOSBundleID:     os.Getenv("IOS_BUNDLE_ID"),
 	}
 
 	if err := validator.New().Struct(cfg); err != nil {

--- a/backend/internal/controllers/invite_page.go
+++ b/backend/internal/controllers/invite_page.go
@@ -18,6 +18,17 @@ func NewInvitePageController(invitePageService services.InvitePageServiceInterfa
 	}
 }
 
+// InvitePage handles GET /invite/:code — universal link landing page.
+// When the app is installed, iOS/Android intercepts this URL before it reaches the browser.
+// When the app is not installed, this renders the invite HTML page as a fallback.
+func (ctrl *InvitePageController) InvitePage(c *fiber.Ctx) error {
+	code := c.Params("code")
+	if code == "" {
+		return c.Redirect("/join", http.StatusMovedPermanently)
+	}
+	return ctrl.renderTripInvitePage(c, code)
+}
+
 // JoinPage handles GET /join
 // If ?code= is present, fetches trip data and renders the invite page.
 // If no code, renders the "enter code" form.

--- a/backend/internal/controllers/well_known.go
+++ b/backend/internal/controllers/well_known.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"toggo/internal/config"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type WellKnownController struct {
+	appleTeamID string
+	iosBundleID string
+}
+
+func NewWellKnownController(cfg config.AppConfig) *WellKnownController {
+	return &WellKnownController{
+		appleTeamID: cfg.AppleTeamID,
+		iosBundleID: cfg.IOSBundleID,
+	}
+}
+
+// AppleAppSiteAssociation handles GET /.well-known/apple-app-site-association
+// Required by iOS to validate universal links for this domain.
+func (ctrl *WellKnownController) AppleAppSiteAssociation(c *fiber.Ctx) error {
+	type detail struct {
+		AppIDs     []string            `json:"appIDs"`
+		Components []map[string]string `json:"components"`
+	}
+	type applinks struct {
+		Details []detail `json:"details"`
+	}
+	type aasa struct {
+		AppLinks applinks `json:"applinks"`
+	}
+
+	resp := aasa{
+		AppLinks: applinks{
+			Details: []detail{{
+				AppIDs: []string{ctrl.appleTeamID + "." + ctrl.iosBundleID},
+				Components: []map[string]string{
+					{"/": "/invite/*"},
+				},
+			}},
+		},
+	}
+
+	c.Set("Content-Type", "application/json")
+	return c.JSON(resp)
+}

--- a/backend/internal/server/routers/invite_page.go
+++ b/backend/internal/server/routers/invite_page.go
@@ -21,11 +21,19 @@ func InvitePageRoutes(app *fiber.App, routeParams types.RouteParams) {
 	invitePageService := services.NewInvitePageService(
 		routeParams.ServiceParams.Repository,
 		routeParams.ServiceParams.FileService,
+		routeParams.ServiceParams.Config.App,
 	)
 	invitePageController := controllers.NewInvitePageController(invitePageService)
+	wellKnownController := controllers.NewWellKnownController(routeParams.ServiceParams.Config.App)
 
-	// GET /join — public, no auth required, relaxed COEP for CDN/S3
+	// GET /invite/:code — universal link landing page (iOS intercepts if app is installed)
+	app.Get("/invite/:code", relaxCOEP, invitePageController.InvitePage)
+
+	// GET /join — legacy invite link, kept for backwards compatibility
 	app.Get("/join", relaxCOEP, invitePageController.JoinPage)
+
+	// GET /.well-known/* — required for iOS universal links validation
+	app.Get("/.well-known/apple-app-site-association", wellKnownController.AppleAppSiteAssociation)
 
 	// GET /static/* — embedded assets for server-rendered pages (logo, favicon, etc.)
 	app.Get("/static/*", relaxCOEP, templates.ServeStatic())

--- a/backend/internal/services/invite_page.go
+++ b/backend/internal/services/invite_page.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"os"
 	"strings"
 	"time"
+	"toggo/internal/config"
 	"toggo/internal/errs"
 	"toggo/internal/models"
 	"toggo/internal/repository"
@@ -21,13 +21,21 @@ var _ InvitePageServiceInterface = (*InvitePageService)(nil)
 
 type InvitePageService struct {
 	*repository.Repository
-	fileService FileServiceInterface
+	fileService     FileServiceInterface
+	deepLinkBaseURL string
+	publicURL       string
 }
 
-func NewInvitePageService(repo *repository.Repository, fileService FileServiceInterface) InvitePageServiceInterface {
+func NewInvitePageService(repo *repository.Repository, fileService FileServiceInterface, appConfig config.AppConfig) InvitePageServiceInterface {
+	deepLinkBaseURL := appConfig.DeepLinkBaseURL
+	if deepLinkBaseURL == "" {
+		deepLinkBaseURL = "toggo-app://"
+	}
 	return &InvitePageService{
-		Repository:  repo,
-		fileService: fileService,
+		Repository:      repo,
+		fileService:     fileService,
+		deepLinkBaseURL: deepLinkBaseURL,
+		publicURL:       appConfig.PublicURL,
 	}
 }
 
@@ -81,19 +89,13 @@ func (s *InvitePageService) GetTripInvitePageData(ctx context.Context, code stri
 		}
 	}
 
-	// Build deep link
-	// Expo Go local dev: exp://localhost:8081/--/invite/CODE
-	// Production:        toggo://invite/CODE
-	deepLinkBase := os.Getenv("DEEPLINK_BASE_URL")
-	if deepLinkBase == "" {
-		deepLinkBase = "exp://localhost:8081/--"
-	}
-	data.DeepLink = template.URL(fmt.Sprintf("%s/invite/%s", strings.TrimRight(deepLinkBase, "/"), code))
+	// Build deep link using injected config (falls back to toggo-app:// if not set)
+	base := strings.TrimSuffix(s.deepLinkBaseURL, "/")
+	data.DeepLink = template.URL(fmt.Sprintf("%s/invite/%s", base, code))
 
 	// Build canonical URL
-	baseURL := os.Getenv("APP_PUBLIC_URL")
-	if baseURL != "" {
-		trimmed := strings.TrimRight(baseURL, "/")
+	if s.publicURL != "" {
+		trimmed := strings.TrimRight(s.publicURL, "/")
 		data.CanonicalURL = trimmed + "/join?code=" + code
 	}
 

--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -41,11 +41,24 @@ export const getAuthToken = async (): Promise<string | null> => {
 };
 
 const resolveBaseUrl = (): string => {
+  const isProd = process.env.EXPO_PUBLIC_ENVIRONMENT === "prod";
   const configuredUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
+
+  if (isProd) {
+    if (!configuredUrl) {
+      throw new Error(
+        "EXPO_PUBLIC_API_BASE_URL is required in production. Set it in your environment.",
+      );
+    }
+    return configuredUrl;
+  }
+
+  // Dev: prefer explicitly configured URL (set to Mac IP in .env.local for physical devices)
   if (configuredUrl) {
     return configuredUrl;
   }
 
+  // Fallback: detect host from Expo dev server (works in Expo Go / simulators)
   const constants = Constants as Record<string, any>;
   const debuggerHost =
     constants.expoConfig?.hostUri ??
@@ -67,13 +80,7 @@ const resolveBaseUrl = (): string => {
     return "http://10.0.2.2:8000";
   }
 
-  if (__DEV__) {
-    return "http://localhost:8000";
-  }
-
-  throw new Error(
-    "API base URL is not configured. Set EXPO_PUBLIC_API_BASE_URL in your environment.",
-  );
+  return "http://localhost:8000";
 };
 
 const BASE_URL = resolveBaseUrl();

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "frontend",
     "slug": "frontend",
-    "scheme": "frontend",
+    "scheme": "toggo-app",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -16,6 +16,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.generateneutoggo.frontend",
+      "associatedDomains": ["applinks:dolphin-app-vemv9.ondigitalocean.app"],
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "UIBackgroundModes": ["remote-notification"],

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -3,7 +3,6 @@ import {
   useGetPollsByTripID,
 } from "@/api/polls/useGetPollsByTripID";
 import { useGetRankPollResults } from "@/api/polls/useGetRankPollResults";
-import { useCreateTripInvite } from "@/api/trips/useCreateTripInvite";
 import { getTripQueryKey, useGetTrip } from "@/api/trips/useGetTrip";
 import { useUpdateTrip } from "@/api/trips/useUpdateTrip";
 import { TripReminderDateSheet } from "@/app/(app)/components/trip-reminder-date-sheet";
@@ -30,7 +29,7 @@ import { Layout } from "@/design-system/tokens/layout";
 import { ModelsPollAPIResponse } from "@/types/types.gen";
 import { useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
-import * as Linking from "expo-linking";
+import { useShareTripInvite } from "@/hooks/useShareTripInvite";
 import {
   router,
   Stack,
@@ -55,7 +54,6 @@ import {
   ActivityIndicator,
   Pressable,
   ScrollView,
-  Share,
   StyleSheet,
   View,
 } from "react-native";
@@ -319,7 +317,9 @@ function PollsTabContent({ tripId }: { tripId: string }) {
 export default function Trip() {
   const { id: tripID } = useLocalSearchParams<{ id: string }>();
   const [activeTab, setActiveTab] = useState<TabKey>(INITIAL_TAB);
-  const createInviteMutation = useCreateTripInvite();
+  const { shareInvite, isPending: isInvitePending } = useShareTripInvite(
+    tripID!,
+  );
   const updateTripMutation = useUpdateTrip();
   const queryClient = useQueryClient();
   const dateSheetRef = useRef<any>(null);
@@ -348,25 +348,6 @@ export default function Trip() {
       queryKey: getPollsByTripIDQueryKey(tripID!),
     });
   }, [queryClient, tripID]);
-
-  const handleInvite = async () => {
-    try {
-      const invite = await createInviteMutation.mutateAsync({
-        tripID: tripID!,
-        data: {},
-      });
-      const code = invite.code;
-      if (!code) return;
-
-      const deepLink = Linking.createURL(`invite/${code}`);
-      await Share.share({
-        message: `Join my trip on Toggo! ${deepLink}`,
-        url: deepLink,
-      });
-    } catch {
-      // silently handled
-    }
-  };
 
   const handleDateSet = async (range: DateRange) => {
     if (!range.start) return;
@@ -479,8 +460,8 @@ export default function Trip() {
 
                 <Box flexDirection="row" alignItems="center" gap="sm">
                   <InviteFriendsButton
-                    onPress={handleInvite}
-                    loading={createInviteMutation.isPending}
+                    onPress={shareInvite}
+                    loading={isInvitePending}
                   />
                   <Pressable
                     onPress={() =>

--- a/frontend/app/(app)/trips/[id]/settings/members.tsx
+++ b/frontend/app/(app)/trips/[id]/settings/members.tsx
@@ -1,7 +1,6 @@
 import { useMembersList } from "@/api/memberships/custom/useMembersList";
 import { useGetMembership } from "@/api/memberships/useGetMembership";
 import { usePromoteToAdmin } from "@/api/memberships/usePromoteToAdmin";
-import { useCreateTripInvite } from "@/api/trips/useCreateTripInvite";
 import { useUser } from "@/contexts/user";
 import {
   Avatar,
@@ -17,7 +16,7 @@ import {
 } from "@/design-system";
 import { ColorPalette } from "@/design-system/tokens/color";
 import type { ModelsMembershipAPIResponse } from "@/types/types.gen";
-import * as Linking from "expo-linking";
+import { useShareTripInvite } from "@/hooks/useShareTripInvite";
 import { useLocalSearchParams } from "expo-router";
 import { Crown } from "lucide-react-native";
 import {
@@ -26,7 +25,6 @@ import {
   NativeSyntheticEvent,
   Pressable,
   ScrollView,
-  Share,
 } from "react-native";
 
 function MemberRowSkeleton() {
@@ -128,7 +126,9 @@ export default function MembersSettings() {
     currentUser?.id ?? "",
   );
   const promoteToAdminMutation = usePromoteToAdmin();
-  const createInviteMutation = useCreateTripInvite();
+  const { shareInvite, isPending: isInvitePending } = useShareTripInvite(
+    tripID!,
+  );
 
   const isAdmin = myMembership?.is_admin ?? false;
 
@@ -136,26 +136,6 @@ export default function MembersSettings() {
     const { layoutMeasurement, contentOffset, contentSize } = e.nativeEvent;
     if (layoutMeasurement.height + contentOffset.y >= contentSize.height - 80) {
       fetchMore();
-    }
-  };
-
-  const handleInvite = async () => {
-    try {
-      const invite = await createInviteMutation.mutateAsync({
-        tripID: tripID!,
-        data: {},
-      });
-      const code = invite.code;
-      if (!code) return;
-      const deepLink = Linking.createURL("join", { queryParams: { code } });
-      await Share.share({
-        message: `Join my trip on Toggo! ${deepLink}`,
-        url: deepLink,
-      });
-    } catch {
-      toast.show({
-        message: "Couldn't generate invite link. Please try again.",
-      });
     }
   };
 
@@ -256,14 +236,10 @@ export default function MembersSettings() {
       </Box>
       <Button
         layout="textOnly"
-        label={
-          createInviteMutation.isPending
-            ? "Generating link..."
-            : "Add New Member"
-        }
+        label={isInvitePending ? "Generating link..." : "Add New Member"}
         variant="Secondary"
-        disabled={createInviteMutation.isPending}
-        onPress={handleInvite}
+        disabled={isInvitePending}
+        onPress={shareInvite}
       />
     </ScrollView>
   );

--- a/frontend/hooks/useShareTripInvite.ts
+++ b/frontend/hooks/useShareTripInvite.ts
@@ -1,0 +1,28 @@
+import { useCreateTripInvite } from "@/api/trips/useCreateTripInvite";
+import * as Linking from "expo-linking";
+import { Share } from "react-native";
+
+export function useShareTripInvite(tripID: string) {
+  const createInviteMutation = useCreateTripInvite();
+
+  const shareInvite = async () => {
+    try {
+      const invite = await createInviteMutation.mutateAsync({
+        tripID,
+        data: {},
+      });
+      const code = invite.code;
+      if (!code) return;
+
+      const deepLink = Linking.createURL("join", { queryParams: { code } });
+      await Share.share({
+        message: "Join my trip on Toggo!",
+        url: deepLink,
+      });
+    } catch {
+      // silently handled — callers can check isPending/isError if needed
+    }
+  };
+
+  return { shareInvite, isPending: createInviteMutation.isPending };
+}

--- a/frontend/hooks/useShareTripInvite.ts
+++ b/frontend/hooks/useShareTripInvite.ts
@@ -1,6 +1,7 @@
 import { useCreateTripInvite } from "@/api/trips/useCreateTripInvite";
-import * as Linking from "expo-linking";
 import { Share } from "react-native";
+
+const API_URL = process.env.EXPO_PUBLIC_API_BASE_URL;
 
 export function useShareTripInvite(tripID: string) {
   const createInviteMutation = useCreateTripInvite();
@@ -14,10 +15,10 @@ export function useShareTripInvite(tripID: string) {
       const code = invite.code;
       if (!code) return;
 
-      const deepLink = Linking.createURL("join", { queryParams: { code } });
+      const inviteLink = `${API_URL}/invite/${code}`;
       await Share.share({
         message: "Join my trip on Toggo!",
-        url: deepLink,
+        url: inviteLink,
       });
     } catch {
       // silently handled — callers can check isPending/isError if needed


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Centralized trip invite creation and native sharing into a new reusable hook `useShareTripInvite`, and updated trip page and members settings to use it
- Standardized invite deep-link and share flow across trip UI (trip page + members settings), removing local async/share handlers
- Added server-side universal-link support (/.well-known/apple-app-site-association, /invite/:code) and app config for public URL / deep-linking
- Updated Expo app scheme to "toggo-app" and added iOS associatedDomains to enable Universal Links

**Improvements**
- Introduced `useShareTripInvite` to encapsulate invite creation, deep link construction, and native share invocation
- Refactored `frontend/app/(app)/trips/[id]/index.tsx` and `frontend/app/(app)/trips/[id]/settings/members.tsx` to call `shareInvite` and reflect hook `isPending` state instead of in-component invite logic
- Backend: added AppConfig fields (PublicURL, DeepLinkBaseURL, AppleTeamID, IOSBundleID), new WellKnownController for Apple App Site Association, InvitePage controller/route, and updated invite page service wiring to use injected app config
- Frontend: resolved API base URL resolution behavior and Expo app scheme/associated domains for universal links

Author contribution

| File | Added | Removed | Net |
|------|-------:|--------:|----:|
| frontend/hooks/useShareTripInvite.ts | 29 | 0 | +29 |
| frontend/app/(app)/trips/[id]/index.tsx | 6 | 25 | -19 |
| frontend/app/(app)/trips/[id]/settings/members.tsx | 7 | 31 | -24 |
| **Total** | **42** | **56** | **-14** |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->