### PR TITLE
Add trip location column

### DIFF
--- a/backend/internal/migrations/20260408035247_add_location_to_trip.sql
+++ b/backend/internal/migrations/20260408035247_add_location_to_trip.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+ALTER TABLE trips ADD COLUMN location VARCHAR(255);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+ALTER TABLE trips DROP COLUMN location;
+-- +goose StatementEnd

--- a/backend/internal/migrations/20260408035247_add_location_to_trip.sql
+++ b/backend/internal/migrations/20260408035247_add_location_to_trip.sql
@@ -1,11 +1,9 @@
 -- +goose Up
 -- +goose StatementBegin
-SELECT 'up SQL query';
 ALTER TABLE trips ADD COLUMN location VARCHAR(255);
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-SELECT 'down SQL query';
 ALTER TABLE trips DROP COLUMN location;
 -- +goose StatementEnd

--- a/backend/internal/models/trips.go
+++ b/backend/internal/models/trips.go
@@ -17,6 +17,7 @@ type Trip struct {
 	RankPollID    *uuid.UUID `bun:"rank_poll_id,type:uuid" json:"rank_poll_id,omitempty"`
 	StartDate     *time.Time `bun:"start_date" json:"start_date,omitempty"`
 	EndDate       *time.Time `bun:"end_date" json:"end_date,omitempty"`
+	Location      *string    `bun:"location" json:"location,omitempty"`
 	CreatedAt     time.Time  `bun:"created_at,nullzero" json:"created_at"`
 	UpdatedAt     time.Time  `bun:"updated_at,nullzero" json:"updated_at"`
 }
@@ -30,6 +31,7 @@ type UpdateTripRequest struct {
 	StartDate     *time.Time `json:"start_date,omitempty" swaggertype:"string" format:"date-time"`
 	EndDate       *time.Time `json:"end_date,omitempty" swaggertype:"string" format:"date-time"`
 	PitchDeadline *time.Time `json:"pitch_deadline,omitempty"`
+	Location      *string    `json:"location,omitempty"`
 }
 
 type CreateTripRequest struct {
@@ -73,6 +75,7 @@ type TripDatabaseResponse struct {
 	RankPollID    *uuid.UUID `bun:"rank_poll_id"`
 	StartDate     *time.Time `bun:"start_date"`
 	EndDate       *time.Time `bun:"end_date"`
+	Location      *string    `bun:"location"`
 	CreatedAt     time.Time  `bun:"created_at"`
 	UpdatedAt     time.Time  `bun:"updated_at"`
 }
@@ -88,6 +91,7 @@ type TripAPIResponse struct {
 	RankPollID    *uuid.UUID `json:"rank_poll_id,omitempty"`
 	StartDate     *time.Time `json:"start_date,omitempty" swaggertype:"string" format:"date-time"`
 	EndDate       *time.Time `json:"end_date,omitempty" swaggertype:"string" format:"date-time"`
+	Location      *string    `json:"location,omitempty"`
 	CreatedAt     time.Time  `json:"created_at"`
 	UpdatedAt     time.Time  `json:"updated_at"`
 }

--- a/backend/internal/repository/trips.go
+++ b/backend/internal/repository/trips.go
@@ -67,7 +67,7 @@ func (r *tripRepository) FindWithCoverImage(ctx context.Context, id uuid.UUID) (
 	tripData := &models.TripDatabaseResponse{}
 	err := r.db.NewSelect().
 		TableExpr("trips AS t").
-		ColumnExpr("t.id AS trip_id, t.name, t.budget_min, t.budget_max, t.currency, t.pitch_deadline, t.rank_poll_id, t.start_date, t.end_date, t.created_at, t.updated_at").
+		ColumnExpr("t.id AS trip_id, t.name, t.budget_min, t.budget_max, t.currency, t.pitch_deadline, t.rank_poll_id, t.start_date, t.end_date, t.location, t.created_at, t.updated_at").
 		ColumnExpr("t.cover_image").
 		ColumnExpr("img.file_key AS cover_image_key").
 		Join("LEFT JOIN images AS img ON t.cover_image IS NOT NULL AND img.image_id = t.cover_image AND img.size = ? AND img.status = ?", models.ImageSizeMedium, models.UploadStatusConfirmed).
@@ -116,7 +116,7 @@ func (r *tripRepository) FindAllWithCursor(ctx context.Context, userID uuid.UUID
 func (r *tripRepository) FindAllWithCursorAndCoverImage(ctx context.Context, userID uuid.UUID, limit int, cursor *models.TripCursor) ([]*models.TripDatabaseResponse, *models.TripCursor, error) {
 	query := r.db.NewSelect().
 		TableExpr("trips AS t").
-		ColumnExpr("t.id AS trip_id, t.name, t.budget_min, t.budget_max, t.currency, t.pitch_deadline, t.rank_poll_id, t.start_date, t.end_date, t.created_at, t.updated_at").
+		ColumnExpr("t.id AS trip_id, t.name, t.budget_min, t.budget_max, t.currency, t.pitch_deadline, t.rank_poll_id, t.start_date, t.end_date, t.location, t.created_at, t.updated_at").
 		ColumnExpr("t.cover_image").
 		ColumnExpr("img.file_key AS cover_image_key").
 		Join("JOIN memberships AS m ON m.trip_id = t.id").
@@ -237,6 +237,9 @@ func (r *tripRepository) UpdateTx(ctx context.Context, tx bun.Tx, id uuid.UUID, 
 	}
 	if req.EndDate != nil {
 		updateQuery = updateQuery.Set("end_date = ?", *req.EndDate)
+	}
+	if req.Location != nil {
+		updateQuery = updateQuery.Set("location = ?", *req.Location)
 	}
 
 	result, err := updateQuery.Exec(ctx)

--- a/backend/internal/services/trips.go
+++ b/backend/internal/services/trips.go
@@ -201,6 +201,7 @@ func (s *TripService) convertToAPITrips(tripsData []*models.TripDatabaseResponse
 			RankPollID:    tripData.RankPollID,
 			StartDate:     tripData.StartDate,
 			EndDate:       tripData.EndDate,
+			Location:      tripData.Location,
 			CreatedAt:     tripData.CreatedAt,
 			UpdatedAt:     tripData.UpdatedAt,
 		})
@@ -318,6 +319,7 @@ func (s *TripService) toAPIResponse(ctx context.Context, tripData *models.TripDa
 		RankPollID:    tripData.RankPollID,
 		StartDate:     tripData.StartDate,
 		EndDate:       tripData.EndDate,
+		Location:      tripData.Location,
 		CreatedAt:     tripData.CreatedAt,
 		UpdatedAt:     tripData.UpdatedAt,
 	}, nil

--- a/backend/internal/tests/trip_location_test.go
+++ b/backend/internal/tests/trip_location_test.go
@@ -1,0 +1,253 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"toggo/internal/models"
+	testkit "toggo/internal/tests/testkit/builders"
+	"toggo/internal/tests/testkit/fakes"
+)
+
+func TestTripLocation(t *testing.T) {
+	app := fakes.GetSharedTestApp()
+	ownerID := createUser(t, app)
+
+	t.Run("create trip without location", func(t *testing.T) {
+		resp := testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  "/api/v1/trips",
+				Method: testkit.POST,
+				UserID: &ownerID,
+				Body: models.CreateTripRequest{
+					Name:      "Trip Without Location",
+					BudgetMin: 100,
+					BudgetMax: 500,
+				},
+			}).
+			AssertStatus(http.StatusCreated).
+			GetBody()
+
+		_, hasLocation := resp["location"]
+		require.False(t, hasLocation, "location should not be present when not set")
+	})
+
+	t.Run("update trip with location", func(t *testing.T) {
+		tripID := createTrip(t, app, ownerID)
+
+		location := "Paris, France"
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &location,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", location)
+	})
+
+	t.Run("get trip with location", func(t *testing.T) {
+		tripID := createTrip(t, app, ownerID)
+
+		location := "Tokyo, Japan"
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &location,
+				},
+			}).
+			AssertStatus(http.StatusOK)
+
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.GET,
+				UserID: &ownerID,
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", location)
+	})
+
+	t.Run("location appears in list response", func(t *testing.T) {
+		listOwnerID := createUser(t, app)
+
+		location := "New York, NY, USA"
+		resp := testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  "/api/v1/trips",
+				Method: testkit.POST,
+				UserID: &listOwnerID,
+				Body: models.CreateTripRequest{
+					Name:      "Listed Trip With Location",
+					BudgetMin: 100,
+					BudgetMax: 500,
+				},
+			}).
+			AssertStatus(http.StatusCreated).
+			GetBody()
+
+		tripID := resp["id"].(string)
+
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &listOwnerID,
+				Body: models.UpdateTripRequest{
+					Location: &location,
+				},
+			}).
+			AssertStatus(http.StatusOK)
+
+		listResp := testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  "/api/v1/trips",
+				Method: testkit.GET,
+				UserID: &listOwnerID,
+			}).
+			AssertStatus(http.StatusOK).
+			GetBody()
+
+		items := listResp["items"].([]interface{})
+		require.Equal(t, 1, len(items))
+		trip := items[0].(map[string]interface{})
+		require.Equal(t, tripID, trip["id"])
+		require.Equal(t, location, trip["location"])
+	})
+
+	t.Run("update location to different value", func(t *testing.T) {
+		tripID := createTrip(t, app, ownerID)
+
+		firstLocation := "London, UK"
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &firstLocation,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", firstLocation)
+
+		secondLocation := "Barcelona, Spain"
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &secondLocation,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", secondLocation)
+
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.GET,
+				UserID: &ownerID,
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", secondLocation)
+	})
+
+	t.Run("location can be set to empty string", func(t *testing.T) {
+		tripID := createTrip(t, app, ownerID)
+
+		location := "Berlin, Germany"
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &location,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", location)
+
+		emptyLocation := ""
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &emptyLocation,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", emptyLocation)
+	})
+
+	t.Run("location accepts long strings", func(t *testing.T) {
+		tripID := createTrip(t, app, ownerID)
+
+		longLocation := "1600 Amphitheatre Parkway, Mountain View, CA 94043, United States of America"
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Location: &longLocation,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("location", longLocation)
+	})
+
+	t.Run("update location along with other fields", func(t *testing.T) {
+		tripID := createTrip(t, app, ownerID)
+
+		newName := "Updated Trip Name"
+		location := "Amsterdam, Netherlands"
+		budgetMin := 200
+		budgetMax := 800
+
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s", tripID),
+				Method: testkit.PATCH,
+				UserID: &ownerID,
+				Body: models.UpdateTripRequest{
+					Name:      &newName,
+					Location:  &location,
+					BudgetMin: &budgetMin,
+					BudgetMax: &budgetMax,
+				},
+			}).
+			AssertStatus(http.StatusOK).
+			AssertField("name", newName).
+			AssertField("location", location).
+			AssertField("budget_min", float64(200)).
+			AssertField("budget_max", float64(800))
+	})
+}

--- a/frontend/api/files/custom/useUploadTripCoverImage.ts
+++ b/frontend/api/files/custom/useUploadTripCoverImage.ts
@@ -1,0 +1,65 @@
+import type { UseMutationOptions } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
+import { uploadImage } from "../../../services/imageService";
+import type {
+  UploadError400,
+  UploadError500,
+  UploadImageResponse,
+} from "../../../types/images";
+import type { ResponseErrorConfig } from "../../client";
+
+type UploadError = ResponseErrorConfig<UploadError400 | UploadError500>;
+
+/**
+ * Hook to upload a trip cover image (medium size variant).
+ *
+ * @param options - Optional mutation options
+ * @return Mutation object for uploading trip cover image
+ *
+ * @example
+ * ```tsx
+ * function TripCoverImageUploader() {
+ *   const uploadMutation = useUploadTripCoverImage({
+ *     onSuccess: (data) => {
+ *       console.log("Cover image uploaded:", data.imageId);
+ *       // Update trip with the imageId
+ *     },
+ *     onError: (error) => {
+ *       console.error("Upload failed:", error);
+ *     },
+ *   });
+ *
+ *   const handlePickImage = async () => {
+ *     const result = await ImagePicker.launchImageLibraryAsync({
+ *       mediaTypes: ["images"],
+ *       allowsEditing: true,
+ *       aspect: [16, 9],  // Landscape ratio for cover images
+ *       quality: 1,
+ *     });
+ *
+ *     if (!result.canceled && result.assets[0]?.uri) {
+ *       uploadMutation.mutate({ uri: result.assets[0].uri });
+ *     }
+ *   };
+ *
+ *   return (
+ *     <Button onPress={handlePickImage} disabled={uploadMutation.isPending}>
+ *       {uploadMutation.isPending ? "Uploading..." : "Add Cover Image"}
+ *     </Button>
+ *   );
+ * }
+ * ```
+ */
+export function useUploadTripCoverImage(
+  options?: UseMutationOptions<
+    UploadImageResponse,
+    UploadError,
+    { uri: string }
+  >,
+) {
+  return useMutation<UploadImageResponse, UploadError, { uri: string }>({
+    mutationKey: ["upload-trip-cover-image"],
+    mutationFn: ({ uri }) => uploadImage({ uri, sizes: ["medium"] }),
+    ...options,
+  });
+}

--- a/frontend/api/files/custom/useUploadTripCoverImage.ts
+++ b/frontend/api/files/custom/useUploadTripCoverImage.ts
@@ -51,10 +51,9 @@ type UploadError = ResponseErrorConfig<UploadError400 | UploadError500>;
  * ```
  */
 export function useUploadTripCoverImage(
-  options?: UseMutationOptions<
-    UploadImageResponse,
-    UploadError,
-    { uri: string }
+  options?: Omit<
+    UseMutationOptions<UploadImageResponse, UploadError, { uri: string }>,
+    "mutationKey" | "mutationFn"
   >,
 ) {
   return useMutation<UploadImageResponse, UploadError, { uri: string }>({

--- a/frontend/app/(app)/_layout.tsx
+++ b/frontend/app/(app)/_layout.tsx
@@ -1,45 +1,6 @@
-import { useHomeUIStore } from "@/app/(app)/store/home-ui-store";
 import { useUser } from "@/contexts/user";
-import {
-  BackButton,
-  Box,
-  Button,
-  Logo,
-  ProfileAvatarButton,
-  ToastProvider,
-} from "@/design-system";
-import { useProfileAvatar } from "@/hooks/use-profile-avatar";
-import { Redirect, router, Stack } from "expo-router";
-import { PlusIcon } from "lucide-react-native";
-
-function HomeHeaderLeft() {
-  const profile = useProfileAvatar();
-  return (
-    <ProfileAvatarButton
-      profilePhoto={profile.profilePhotoUri}
-      seed={profile.seed}
-      size="lg"
-      accessibilityLabel={profile.accessibilityLabel}
-      onPress={() => router.push("/settings")}
-    />
-  );
-}
-
-function HomeHeaderRight() {
-  const requestCreateTripSheet = useHomeUIStore(
-    (s) => s.requestCreateTripSheet,
-  );
-
-  return (
-    <Button
-      accessibilityLabel="Create a trip"
-      icon={PlusIcon}
-      variant="IconSecondary"
-      layout="iconOnly"
-      onPress={requestCreateTripSheet}
-    />
-  );
-}
+import { BackButton, ToastProvider } from "@/design-system";
+import { Redirect, Stack } from "expo-router";
 
 const Layout = () => {
   const { isAuthenticated } = useUser();
@@ -54,18 +15,7 @@ const Layout = () => {
         <Stack.Screen
           name="index"
           options={{
-            headerShown: true,
-            headerTransparent: false,
-            headerTitle: () => (
-              <Box paddingTop="sm">
-                <Logo size="xl" />
-              </Box>
-            ),
-            headerTitleAlign: "center",
-            headerShadowVisible: false,
-            headerLeft: () => <HomeHeaderLeft />,
-            headerRight: () => <HomeHeaderRight />,
-            gestureEnabled: false,
+            headerShown: false,
           }}
         />
         <Stack.Screen

--- a/frontend/app/(app)/components/home/constants.ts
+++ b/frontend/app/(app)/components/home/constants.ts
@@ -1,7 +1,7 @@
 /** First page of trips on the home screen; matches API default max page size intent. */
 export const HOME_TRIPS_PAGE_SIZE = 20;
 
-export const HOME_UPCOMING_IMAGE_HEIGHT = 140;
+export const HOME_UPCOMING_IMAGE_HEIGHT = 170;
 export const HOME_PAST_TRIP_IMAGE_SIZE = 72;
 export const HOME_RECOMMENDED_CARD_WIDTH = 250;
 

--- a/frontend/app/(app)/components/home/recommended-trips-row.tsx
+++ b/frontend/app/(app)/components/home/recommended-trips-row.tsx
@@ -9,13 +9,17 @@ import {
 export function RecommendedTripsRow() {
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-      <Box flexDirection="row" gap="sm" paddingRight="md">
+      <Box flexDirection="row" gap="sm" paddingHorizontal="sm" paddingVertical="sm">
         {RECOMMENDED_DESTINATIONS.map((destination) => (
           <Box
             key={destination.id}
             width={HOME_RECOMMENDED_CARD_WIDTH}
             borderRadius="md"
             backgroundColor="white"
+            shadowColor="black"
+            shadowOpacity={0.2}
+            shadowOffset={{ width: 0, height: 2 }}
+            shadowRadius={4}
             padding="xs"
             gap="sm"
           >

--- a/frontend/app/(app)/components/home/recommended-trips-row.tsx
+++ b/frontend/app/(app)/components/home/recommended-trips-row.tsx
@@ -9,7 +9,12 @@ import {
 export function RecommendedTripsRow() {
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-      <Box flexDirection="row" gap="sm" paddingHorizontal="sm" paddingVertical="sm">
+      <Box
+        flexDirection="row"
+        gap="sm"
+        paddingHorizontal="sm"
+        paddingVertical="sm"
+      >
         {RECOMMENDED_DESTINATIONS.map((destination, index) => (
           <Box
             key={destination.id}
@@ -22,7 +27,9 @@ export function RecommendedTripsRow() {
             shadowRadius={7}
             padding="xs"
             gap="sm"
-            style={index === 0 ? { transform: [{ rotate: "-1deg" }] } : undefined}
+            style={
+              index === 0 ? { transform: [{ rotate: "-1deg" }] } : undefined
+            }
           >
             <Box height={166} borderRadius="sm" overflow="hidden">
               <Image

--- a/frontend/app/(app)/components/home/recommended-trips-row.tsx
+++ b/frontend/app/(app)/components/home/recommended-trips-row.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from "@/design-system";
 import { Image } from "expo-image";
 import { ScrollView } from "react-native";
 import {
+  HOME_CARD_FLOATING_SHADOW,
   HOME_RECOMMENDED_CARD_WIDTH,
   RECOMMENDED_DESTINATIONS,
 } from "./constants";
@@ -21,15 +22,12 @@ export function RecommendedTripsRow() {
             width={HOME_RECOMMENDED_CARD_WIDTH}
             borderRadius="md"
             backgroundColor="white"
-            shadowColor="black"
-            shadowOpacity={0.2}
-            shadowOffset={{ width: 0, height: 2 }}
-            shadowRadius={7}
             padding="xs"
             gap="sm"
-            style={
-              index === 0 ? { transform: [{ rotate: "-1deg" }] } : undefined
-            }
+            style={[
+              HOME_CARD_FLOATING_SHADOW,
+              index === 0 ? { transform: [{ rotate: "-1deg" }] } : undefined,
+            ]}
           >
             <Box height={166} borderRadius="sm" overflow="hidden">
               <Image

--- a/frontend/app/(app)/components/home/recommended-trips-row.tsx
+++ b/frontend/app/(app)/components/home/recommended-trips-row.tsx
@@ -19,7 +19,7 @@ export function RecommendedTripsRow() {
             shadowColor="black"
             shadowOpacity={0.2}
             shadowOffset={{ width: 0, height: 2 }}
-            shadowRadius={4}
+            shadowRadius={7}
             padding="xs"
             gap="sm"
             style={index === 0 ? { transform: [{ rotate: "-1deg" }] } : undefined}

--- a/frontend/app/(app)/components/home/recommended-trips-row.tsx
+++ b/frontend/app/(app)/components/home/recommended-trips-row.tsx
@@ -10,7 +10,7 @@ export function RecommendedTripsRow() {
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
       <Box flexDirection="row" gap="sm" paddingHorizontal="sm" paddingVertical="sm">
-        {RECOMMENDED_DESTINATIONS.map((destination) => (
+        {RECOMMENDED_DESTINATIONS.map((destination, index) => (
           <Box
             key={destination.id}
             width={HOME_RECOMMENDED_CARD_WIDTH}
@@ -22,6 +22,7 @@ export function RecommendedTripsRow() {
             shadowRadius={4}
             padding="xs"
             gap="sm"
+            style={index === 0 ? { transform: [{ rotate: "-1deg" }] } : undefined}
           >
             <Box height={166} borderRadius="sm" overflow="hidden">
               <Image

--- a/frontend/app/(app)/components/home/upcoming-trip-hero-card.tsx
+++ b/frontend/app/(app)/components/home/upcoming-trip-hero-card.tsx
@@ -40,7 +40,7 @@ export function UpcomingTripHeroCard({
         backgroundColor="white"
         borderRadius="md"
         padding="xs"
-        gap="sm"
+        gap="xs"
         style={[HOME_CARD_FLOATING_SHADOW, width ? { width } : undefined]}
       >
         <Box borderRadius="sm" overflow="hidden">
@@ -83,7 +83,7 @@ export function UpcomingTripHeroCard({
         </Box>
 
         <Box paddingHorizontal="xs" gap="xxs">
-          <Text variant="headingSm" color="gray900">
+          <Text variant="headingMd" color="gray900">
             {trip.name?.trim() || "Untitled trip"}
           </Text>
           <TripMemberPreviewRow tripId={tripId} currentUserId={currentUserId} />

--- a/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
@@ -23,6 +23,8 @@ type TripReminderDateSheetProps = {
   onSkip: () => void;
   /** Called when the sheet is dismissed by gesture or backdrop tap (not button presses). */
   onDismiss?: () => void;
+  /** Error message to display in the sheet. */
+  error?: string | null;
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -47,6 +49,7 @@ export function TripReminderDateSheet({
   onSetDate,
   onSkip,
   onDismiss,
+  error,
 }: TripReminderDateSheetProps) {
   const [dateRange, setDateRange] = useState<DateRange>({
     start: null,
@@ -114,6 +117,20 @@ export function TripReminderDateSheet({
                 </Text>
               </Box>
             </TouchableOpacity>
+
+            {error && (
+              <Box
+                padding="sm"
+                backgroundColor="gray50"
+                borderRadius="sm"
+                borderWidth={1}
+                borderColor="statusError"
+              >
+                <Text variant="bodySmDefault" color="statusError">
+                  {error}
+                </Text>
+              </Box>
+            )}
 
             <Button
               layout="textOnly"

--- a/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
@@ -59,12 +59,14 @@ export function TripReminderDateSheet({
 
   return (
     <>
-      <BottomSheet
-        ref={bottomSheetRef}
-        size="xs"
-        onClose={onDismiss}
-      >
-        <Box flex={1} paddingHorizontal="sm" paddingBottom="lg" justifyContent="flex-end" gap="sm">
+      <BottomSheet ref={bottomSheetRef} size="xs" onClose={onDismiss}>
+        <Box
+          flex={1}
+          paddingHorizontal="sm"
+          paddingBottom="lg"
+          justifyContent="flex-end"
+          gap="sm"
+        >
           <Box gap="xxs">
             <Box flexDirection="row" justifyContent="space-between">
               <Text variant="headingMd" color="gray950">

--- a/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Button,
   DateRangePicker,
-  Divider,
   Text,
 } from "@/design-system";
 import type { DateRange } from "@/design-system/primitives/date-picker";
@@ -62,7 +61,7 @@ export function TripReminderDateSheet({
     <>
       <BottomSheet
         ref={bottomSheetRef}
-        size="sm"
+        size="xs"
         onClose={onDismiss}
       >
         <Box flex={1} paddingHorizontal="sm" paddingBottom="lg" justifyContent="flex-end" gap="sm">
@@ -128,8 +127,6 @@ export function TripReminderDateSheet({
               onPress={onSkip}
             />
           </Box>
-
-          <Divider />
         </Box>
       </BottomSheet>
 

--- a/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
@@ -10,7 +10,7 @@ import type { DateRange } from "@/design-system/primitives/date-picker";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
-import { Calendar, X } from "lucide-react-native";
+import { Calendar } from "lucide-react-native";
 import { useState } from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 
@@ -38,7 +38,7 @@ function formatDateRange(range: DateRange): string | null {
   const start = range.start.toLocaleDateString("en-US", DATE_FORMAT_OPTIONS);
   if (!range.end) return start;
   const end = range.end.toLocaleDateString("en-US", DATE_FORMAT_OPTIONS);
-  return `${start} – ${end}`;
+  return `${start} - ${end}`;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -66,17 +66,6 @@ export function TripReminderDateSheet({
         onClose={onDismiss}
       >
         <Box paddingHorizontal="sm" paddingTop="sm" paddingBottom="lg" gap="md">
-          <Box flexDirection="row" justifyContent="flex-end">
-            <TouchableOpacity
-              onPress={onSkip}
-              hitSlop={styles.hitSlop}
-              accessibilityRole="button"
-              accessibilityLabel="Close"
-            >
-              <X size={20} color={ColorPalette.gray950} />
-            </TouchableOpacity>
-          </Box>
-
           <Box gap="xxs">
             <Text variant="headingMd" color="gray950">
               Lock in the dates

--- a/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-date-sheet.tsx
@@ -10,7 +10,7 @@ import type { DateRange } from "@/design-system/primitives/date-picker";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
-import { Calendar } from "lucide-react-native";
+import { Calendar, X } from "lucide-react-native";
 import { useState } from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 
@@ -62,14 +62,24 @@ export function TripReminderDateSheet({
     <>
       <BottomSheet
         ref={bottomSheetRef}
-        snapPoints={["50%"]}
+        size="sm"
         onClose={onDismiss}
       >
-        <Box paddingHorizontal="sm" paddingTop="sm" paddingBottom="lg" gap="md">
+        <Box flex={1} paddingHorizontal="sm" paddingBottom="lg" justifyContent="flex-end" gap="sm">
           <Box gap="xxs">
-            <Text variant="headingMd" color="gray950">
-              Lock in the dates
-            </Text>
+            <Box flexDirection="row" justifyContent="space-between">
+              <Text variant="headingMd" color="gray950">
+                Lock in the dates
+              </Text>
+              <TouchableOpacity
+                onPress={onSkip}
+                hitSlop={styles.hitSlop}
+                accessibilityRole="button"
+                accessibilityLabel="Close"
+              >
+                <X size={20} color={ColorPalette.gray950} />
+              </TouchableOpacity>
+            </Box>
             <Text variant="bodyDefault" color="gray500">
               Set your trip dates
             </Text>

--- a/frontend/app/(app)/components/trip-reminder-location-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-location-sheet.tsx
@@ -1,10 +1,4 @@
-import {
-  BottomSheet,
-  Box,
-  Button,
-  Text,
-  TextField,
-} from "@/design-system";
+import { BottomSheet, Box, Button, Text, TextField } from "@/design-system";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { X } from "lucide-react-native";
 import { useState } from "react";

--- a/frontend/app/(app)/components/trip-reminder-location-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-location-sheet.tsx
@@ -2,7 +2,6 @@ import {
   BottomSheet,
   Box,
   Button,
-  Divider,
   Text,
   TextField,
 } from "@/design-system";
@@ -34,23 +33,29 @@ export function TripReminderLocationSheet({
   const [destination, setDestination] = useState("");
 
   return (
-    <BottomSheet ref={bottomSheetRef} snapPoints={["55%"]} onClose={onDismiss}>
-      <Box paddingHorizontal="sm" paddingTop="sm" paddingBottom="lg" gap="md">
-        <Box flexDirection="row" justifyContent="flex-end">
-          <TouchableOpacity
-            onPress={onDismiss}
-            hitSlop={styles.hitSlop}
-            accessibilityRole="button"
-            accessibilityLabel="Close"
-          >
-            <X size={20} color={ColorPalette.gray950} />
-          </TouchableOpacity>
-        </Box>
-
+    <BottomSheet ref={bottomSheetRef} size="xs" onClose={onDismiss}>
+      <Box
+        flex={1}
+        paddingHorizontal="sm"
+        paddingBottom="lg"
+        justifyContent="flex-end"
+        gap="sm"
+      >
         <Box gap="xxs">
-          <Text variant="headingMd" color="gray950">
-            Know where you're going?
-          </Text>
+          <Box flexDirection="row" justifyContent="space-between">
+            <Text variant="headingMd" color="gray950">
+              Know where you're going?
+            </Text>
+            <TouchableOpacity
+              onPress={onDismiss}
+              hitSlop={styles.hitSlop}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+            >
+              <X size={20} color={ColorPalette.gray950} />
+            </TouchableOpacity>
+          </Box>
+
           <Text variant="bodyDefault" color="gray500">
             Set your trip location
           </Text>
@@ -76,8 +81,6 @@ export function TripReminderLocationSheet({
             onPress={onVoteOnLocation}
           />
         </Box>
-
-        <Divider />
       </Box>
     </BottomSheet>
   );

--- a/frontend/app/(app)/components/trip-reminder-location-sheet.tsx
+++ b/frontend/app/(app)/components/trip-reminder-location-sheet.tsx
@@ -41,7 +41,7 @@ export function TripReminderLocationSheet({
               Know where you're going?
             </Text>
             <TouchableOpacity
-              onPress={onDismiss}
+              onPress={() => bottomSheetRef.current?.close()}
               hitSlop={styles.hitSlop}
               accessibilityRole="button"
               accessibilityLabel="Close"

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -443,11 +443,11 @@ export default function HomeScreen() {
             </Box>
           </Box>
 
-          <Box gap="sm">
-            <Box paddingHorizontal="sm" paddingVertical="xs">
+          <Box gap="xxs">
+            <Box paddingHorizontal="sm" paddingTop="xs">
               <Text variant="headingXl">Recommended Trips</Text>
             </Box>
-            <Box paddingHorizontal="sm">
+            <Box>
               <RecommendedTripsRow />
             </Box>
           </Box>

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -332,7 +332,7 @@ export default function HomeScreen() {
                     />
                   ) : null}
                   <Text
-                    variant="headingMd"
+                    variant="headingXl"
                     color="gray900"
                     paddingBottom="sm"
                     paddingTop="sm"
@@ -413,8 +413,8 @@ export default function HomeScreen() {
           </Box>
 
           <Box gap="sm">
-            <Box paddingHorizontal="sm" paddingVertical="xs">
-              <Text variant="headingMd">Past Trips</Text>
+            <Box paddingHorizontal="sm" paddingVertical="xxs">
+              <Text variant="headingXl">Past Trips</Text>
             </Box>
             <Box paddingHorizontal="sm" gap="sm">
               {past.length === 0 ? (
@@ -445,7 +445,7 @@ export default function HomeScreen() {
 
           <Box gap="sm">
             <Box paddingHorizontal="sm" paddingVertical="xs">
-              <Text variant="headingMd">Recommended Trips</Text>
+              <Text variant="headingXl">Recommended Trips</Text>
             </Box>
             <Box paddingHorizontal="sm">
               <RecommendedTripsRow />

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -29,6 +29,8 @@ import {
   ErrorState,
   Icon,
   ImagePicker,
+  Logo,
+  ProfileAvatarButton,
   SkeletonRect,
   Text,
 } from "@/design-system";
@@ -41,7 +43,7 @@ import { encodeMapViewActivitiesParam } from "@/utils/map-view-activities";
 import { useQueries } from "@tanstack/react-query";
 import { LinearGradient } from "expo-linear-gradient";
 import { router, useLocalSearchParams } from "expo-router";
-import { Check, X } from "lucide-react-native";
+import { Check, PlusIcon, X } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import {
   Animated,
@@ -50,6 +52,7 @@ import {
   ScrollView,
   useWindowDimensions,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 /** Example pins around San Francisco for the dev map shortcut. */
 const DEV_MAP_SAMPLE_ACTIVITIES: ModelsActivity[] = [
@@ -294,8 +297,40 @@ export default function HomeScreen() {
   const toastIconColor =
     toastVariant === "error" ? "statusError" : "statusSuccess";
 
+  const requestCreateTripSheet = useHomeUIStore(
+    (s) => s.requestCreateTripSheet,
+  );
+
   return (
     <Box flex={1} backgroundColor="white">
+      <SafeAreaView edges={["top"]} style={{ backgroundColor: "white" }}>
+        <Box
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="space-between"
+          paddingHorizontal="md"
+          paddingVertical="sm"
+        >
+          <ProfileAvatarButton
+            profilePhoto={profile.profilePhotoUri}
+            seed={profile.seed}
+            size="lg"
+            accessibilityLabel={profile.accessibilityLabel}
+            onPress={() => router.push("/settings")}
+          />
+          <Box paddingTop="sm">
+            <Logo size="xl" />
+          </Box>
+          <Button
+            accessibilityLabel="Create a trip"
+            icon={PlusIcon}
+            variant="IconSecondary"
+            layout="iconOnly"
+            onPress={requestCreateTripSheet}
+          />
+        </Box>
+      </SafeAreaView>
+
       <ScrollView
         contentInsetAdjustmentBehavior="never"
         automaticallyAdjustContentInsets={false}

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -303,7 +303,7 @@ export default function HomeScreen() {
 
   return (
     <Box flex={1} backgroundColor="white">
-      <SafeAreaView edges={["top"]} style={{ backgroundColor: "white" }}>
+      <SafeAreaView edges={["top"]} style={{ backgroundColor: ColorPalette.white }}>
         <Box
           flexDirection="row"
           alignItems="center"

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -303,7 +303,10 @@ export default function HomeScreen() {
 
   return (
     <Box flex={1} backgroundColor="white">
-      <SafeAreaView edges={["top"]} style={{ backgroundColor: ColorPalette.white }}>
+      <SafeAreaView
+        edges={["top"]}
+        style={{ backgroundColor: ColorPalette.white }}
+      >
         <Box
           flexDirection="row"
           alignItems="center"

--- a/frontend/app/(app)/trips/[id]/_layout.tsx
+++ b/frontend/app/(app)/trips/[id]/_layout.tsx
@@ -22,10 +22,8 @@ const Layout = () => {
       <Stack.Screen
         name="index"
         options={{
-          headerShown: true,
-          headerTitle: "",
-          headerTransparent: true,
-          gestureEnabled: false,
+          headerShown: false,
+          gestureEnabled: true,
         }}
       />
       <Stack.Screen

--- a/frontend/app/(app)/trips/[id]/components/itinerary-empty-state.tsx
+++ b/frontend/app/(app)/trips/[id]/components/itinerary-empty-state.tsx
@@ -12,7 +12,7 @@ export function ItineraryEmptyState() {
           color="gray950"
           style={styles.emptyStateText}
         >
-          No activites planned. Get planning!
+          No activities planned. Get planning!
         </Text>
       </Box>
     </Box>

--- a/frontend/app/(app)/trips/[id]/components/itinerary-empty-state.tsx
+++ b/frontend/app/(app)/trips/[id]/components/itinerary-empty-state.tsx
@@ -1,0 +1,30 @@
+import { Box, Text } from "@/design-system";
+import { StyleSheet } from "react-native";
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ItineraryEmptyState() {
+  return (
+    <Box borderWidth={1} borderColor="gray200" borderRadius="xl" padding="sm">
+      <Box alignItems="center" paddingVertical="lg">
+        <Text
+          variant="bodySmDefault"
+          color="gray950"
+          style={styles.emptyStateText}
+        >
+          No activites planned. Get planning!
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  emptyStateText: {
+    fontStyle: "italic",
+  },
+});
+
+export default ItineraryEmptyState;

--- a/frontend/app/(app)/trips/[id]/components/trip-header.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-header.tsx
@@ -1,56 +1,24 @@
-import { BackButton } from "@/design-system/components/navigation/arrow";
-import { Box, Text } from "@/design-system";
 import { ColorPalette } from "@/design-system/tokens/color";
-import { CornerRadius } from "@/design-system/tokens/corner-radius";
-import { Layout } from "@/design-system/tokens/layout";
 import { Image } from "expo-image";
-import { Map } from "lucide-react-native";
-import { Pressable, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type TripHeaderProps = {
   coverImageUrl?: string;
-  onMapPress: () => void;
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function TripHeader({ coverImageUrl, onMapPress }: TripHeaderProps) {
-  return (
-    <>
-      {coverImageUrl ? (
-        <Image
-          source={{ uri: coverImageUrl }}
-          style={styles.coverImage}
-          contentFit="cover"
-        />
-      ) : (
-        <View style={[styles.coverImage, styles.coverImageFallback]} />
-      )}
-
-      <Box
-        flexDirection="row"
-        justifyContent="space-between"
-        alignItems="center"
-        paddingHorizontal="sm"
-        paddingVertical="xs"
-      >
-        <BackButton />
-
-        <Pressable
-          onPress={onMapPress}
-          style={styles.mapButton}
-          accessibilityRole="button"
-          accessibilityLabel="View map"
-        >
-          <Map size={16} color={ColorPalette.gray950} />
-          <Text variant="bodySmMedium" color="gray950">
-            Map
-          </Text>
-        </Pressable>
-      </Box>
-    </>
+export function TripHeader({ coverImageUrl }: TripHeaderProps) {
+  return coverImageUrl ? (
+    <Image
+      source={{ uri: coverImageUrl }}
+      style={styles.coverImage}
+      contentFit="cover"
+    />
+  ) : (
+    <View style={[styles.coverImage, styles.coverImageFallback]} />
   );
 }
 
@@ -66,20 +34,6 @@ const styles = StyleSheet.create({
   },
   coverImageFallback: {
     backgroundColor: ColorPalette.gray100,
-  },
-  mapButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: Layout.spacing.xxs,
-    backgroundColor: ColorPalette.white,
-    paddingHorizontal: Layout.spacing.sm,
-    paddingVertical: Layout.spacing.xxs,
-    borderRadius: CornerRadius.full,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2,
   },
 });
 

--- a/frontend/app/(app)/trips/[id]/components/trip-header.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-header.tsx
@@ -2,6 +2,10 @@ import { ColorPalette } from "@/design-system/tokens/color";
 import { Image } from "expo-image";
 import { StyleSheet, View } from "react-native";
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TRIP_HEADER_IMAGE_HEIGHT = 260;
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type TripHeaderProps = {
@@ -30,7 +34,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    height: 260,
+    height: TRIP_HEADER_IMAGE_HEIGHT,
   },
   coverImageFallback: {
     backgroundColor: ColorPalette.gray100,

--- a/frontend/app/(app)/trips/[id]/components/trip-header.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-header.tsx
@@ -1,0 +1,86 @@
+import { BackButton } from "@/design-system/components/navigation/arrow";
+import { Box, Text } from "@/design-system";
+import { ColorPalette } from "@/design-system/tokens/color";
+import { CornerRadius } from "@/design-system/tokens/corner-radius";
+import { Layout } from "@/design-system/tokens/layout";
+import { Image } from "expo-image";
+import { Map } from "lucide-react-native";
+import { Pressable, StyleSheet, View } from "react-native";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TripHeaderProps = {
+  coverImageUrl?: string;
+  onMapPress: () => void;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TripHeader({ coverImageUrl, onMapPress }: TripHeaderProps) {
+  return (
+    <>
+      {coverImageUrl ? (
+        <Image
+          source={{ uri: coverImageUrl }}
+          style={styles.coverImage}
+          contentFit="cover"
+        />
+      ) : (
+        <View style={[styles.coverImage, styles.coverImageFallback]} />
+      )}
+
+      <Box
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="center"
+        paddingHorizontal="sm"
+        paddingVertical="xs"
+      >
+        <BackButton />
+
+        <Pressable
+          onPress={onMapPress}
+          style={styles.mapButton}
+          accessibilityRole="button"
+          accessibilityLabel="View map"
+        >
+          <Map size={16} color={ColorPalette.gray950} />
+          <Text variant="bodySmMedium" color="gray950">
+            Map
+          </Text>
+        </Pressable>
+      </Box>
+    </>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  coverImage: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 260,
+  },
+  coverImageFallback: {
+    backgroundColor: ColorPalette.gray100,
+  },
+  mapButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Layout.spacing.xxs,
+    backgroundColor: ColorPalette.white,
+    paddingHorizontal: Layout.spacing.sm,
+    paddingVertical: Layout.spacing.xxs,
+    borderRadius: CornerRadius.full,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+});
+
+export default TripHeader;

--- a/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
@@ -32,7 +32,7 @@ export function TripMetadata({
   onLocationPress,
 }: TripMetadataProps) {
   return (
-    <Box gap="xs" paddingHorizontal="sm" paddingTop="sm">
+    <Box gap="sm" paddingHorizontal="sm" paddingTop="sm">
       <Box
         flexDirection="row"
         alignItems="center"
@@ -46,7 +46,7 @@ export function TripMetadata({
             borderRadius="xs"
           />
         ) : (
-          <Text variant="headingMd" color="gray950">
+          <Text variant="headingXl" color="gray950">
             {tripName ?? "Trip"}
           </Text>
         )}

--- a/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
@@ -2,7 +2,7 @@ import { Box, Chip, Text } from "@/design-system";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { Layout } from "@/design-system/tokens/layout";
 import { Calendar, MapPin, Settings } from "lucide-react-native";
-import { ActivityIndicator, Pressable, StyleSheet } from "react-native";
+import { Pressable, StyleSheet } from "react-native";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -11,7 +11,6 @@ type TripMetadataProps = {
   tripDate: string | null;
   tripLocation?: string;
   isLoading: boolean;
-  isInvitePending: boolean;
   onInviteFriends: () => void;
   onSettingsPress: () => void;
   onDatePress: () => void;
@@ -25,7 +24,6 @@ export function TripMetadata({
   tripDate,
   tripLocation,
   isLoading,
-  isInvitePending,
   onInviteFriends,
   onSettingsPress,
   onDatePress,
@@ -35,8 +33,9 @@ export function TripMetadata({
     <Box gap="sm" paddingHorizontal="sm" paddingTop="sm">
       <Box
         flexDirection="row"
-        alignItems="center"
+        alignItems="flex-start"
         justifyContent="space-between"
+        gap="md"
       >
         {isLoading ? (
           <Box
@@ -46,17 +45,15 @@ export function TripMetadata({
             borderRadius="xs"
           />
         ) : (
-          <Text variant="headingXl" color="gray950">
-            {tripName ?? "Trip"}
-          </Text>
+          <Box flex={1} style={{ maxWidth: "65%" }}>
+            <Text variant="headingXl" color="gray950">
+              {tripName ?? "Trip"}
+            </Text>
+          </Box>
         )}
 
-        <Box flexDirection="row" alignItems="center" gap="sm">
-          {isInvitePending ? (
-            <ActivityIndicator size="small" color={ColorPalette.gray500} />
-          ) : (
-            <Chip label="+ Invite Friends" onPress={onInviteFriends} />
-          )}
+        <Box flexDirection="row" alignItems="center" gap="sm" flexShrink={0}>
+          <Chip label="+ Invite Friends" onPress={onInviteFriends} />
           <Pressable
             onPress={onSettingsPress}
             hitSlop={styles.hitSlop}

--- a/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
@@ -4,6 +4,12 @@ import { Layout } from "@/design-system/tokens/layout";
 import { Calendar, MapPin, Settings } from "lucide-react-native";
 import { Pressable, StyleSheet } from "react-native";
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SKELETON_WIDTH = 160;
+const SKELETON_HEIGHT = 28;
+const TITLE_MAX_WIDTH = "65%";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type TripMetadataProps = {
@@ -39,13 +45,13 @@ export function TripMetadata({
       >
         {isLoading ? (
           <Box
-            width={160}
-            height={28}
+            width={SKELETON_WIDTH}
+            height={SKELETON_HEIGHT}
             backgroundColor="gray100"
             borderRadius="xs"
           />
         ) : (
-          <Box flex={1} style={{ maxWidth: "65%" }}>
+          <Box flex={1} style={{ maxWidth: TITLE_MAX_WIDTH }}>
             <Text variant="headingXl" color="gray950">
               {tripName ?? "Trip"}
             </Text>

--- a/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
@@ -106,7 +106,12 @@ export function TripMetadata({
 // ─── Styles ───────────────────────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
-  hitSlop: { top: Layout.spacing.xs, bottom: Layout.spacing.xs, left: Layout.spacing.xs, right: Layout.spacing.xs },
+  hitSlop: {
+    top: Layout.spacing.xs,
+    bottom: Layout.spacing.xs,
+    left: Layout.spacing.xs,
+    right: Layout.spacing.xs,
+  },
 });
 
 export default TripMetadata;

--- a/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-metadata.tsx
@@ -1,0 +1,109 @@
+import { Box, Chip, Text } from "@/design-system";
+import { ColorPalette } from "@/design-system/tokens/color";
+import { Layout } from "@/design-system/tokens/layout";
+import { Calendar, MapPin, Settings } from "lucide-react-native";
+import { ActivityIndicator, Pressable, StyleSheet } from "react-native";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TripMetadataProps = {
+  tripName?: string;
+  tripDate: string | null;
+  tripLocation?: string;
+  isLoading: boolean;
+  isInvitePending: boolean;
+  onInviteFriends: () => void;
+  onSettingsPress: () => void;
+  onDatePress: () => void;
+  onLocationPress: () => void;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TripMetadata({
+  tripName,
+  tripDate,
+  tripLocation,
+  isLoading,
+  isInvitePending,
+  onInviteFriends,
+  onSettingsPress,
+  onDatePress,
+  onLocationPress,
+}: TripMetadataProps) {
+  return (
+    <Box gap="xs" paddingHorizontal="sm" paddingTop="sm">
+      <Box
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        {isLoading ? (
+          <Box
+            width={160}
+            height={28}
+            backgroundColor="gray100"
+            borderRadius="xs"
+          />
+        ) : (
+          <Text variant="headingMd" color="gray950">
+            {tripName ?? "Trip"}
+          </Text>
+        )}
+
+        <Box flexDirection="row" alignItems="center" gap="sm">
+          {isInvitePending ? (
+            <ActivityIndicator size="small" color={ColorPalette.gray500} />
+          ) : (
+            <Chip label="+ Invite Friends" onPress={onInviteFriends} />
+          )}
+          <Pressable
+            onPress={onSettingsPress}
+            hitSlop={styles.hitSlop}
+            accessibilityRole="button"
+            accessibilityLabel="Trip settings"
+          >
+            <Settings size={20} color={ColorPalette.gray950} />
+          </Pressable>
+        </Box>
+      </Box>
+
+      <Box gap="xs">
+        <Pressable
+          onPress={onDatePress}
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          accessibilityRole="button"
+          accessibilityLabel="Set trip dates"
+        >
+          <Box flexDirection="row" alignItems="center" gap="xs">
+            <Calendar size={16} color={ColorPalette.gray500} />
+            <Text variant="bodySmDefault" color="gray500">
+              {tripDate ?? "Add dates"}
+            </Text>
+          </Box>
+        </Pressable>
+        <Pressable
+          onPress={onLocationPress}
+          style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
+          accessibilityRole="button"
+          accessibilityLabel="Set trip location"
+        >
+          <Box flexDirection="row" alignItems="center" gap="xs">
+            <MapPin size={16} color={ColorPalette.gray500} />
+            <Text variant="bodySmDefault" color="gray500">
+              {tripLocation ?? "Add location"}
+            </Text>
+          </Box>
+        </Pressable>
+      </Box>
+    </Box>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  hitSlop: { top: Layout.spacing.xs, bottom: Layout.spacing.xs, left: Layout.spacing.xs, right: Layout.spacing.xs },
+});
+
+export default TripMetadata;

--- a/frontend/app/(app)/trips/[id]/components/trip-tab-bar.tsx
+++ b/frontend/app/(app)/trips/[id]/components/trip-tab-bar.tsx
@@ -1,0 +1,73 @@
+import { Chip } from "@/design-system";
+import { Layout } from "@/design-system/tokens/layout";
+import {
+  BellDot,
+  Binoculars,
+  ChartColumnBig,
+  House,
+  List,
+  PiggyBank,
+  type LucideIcon,
+} from "lucide-react-native";
+import { ScrollView, StyleSheet } from "react-native";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TabKey =
+  | "new"
+  | "itinerary"
+  | "polls"
+  | "housing"
+  | "budget"
+  | "activities"
+  | "settings";
+
+type TripTabBarProps = {
+  activeTab: TabKey;
+  onTabPress: (tab: TabKey) => void;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TripTabBar({ activeTab, onTabPress }: TripTabBarProps) {
+  const tabs: { key: TabKey; label?: string; icon: LucideIcon | undefined }[] =
+    [
+      { key: "new", label: "New", icon: BellDot },
+      { key: "itinerary", label: "Itinerary", icon: List },
+      { key: "polls", label: "Polls", icon: ChartColumnBig },
+      { key: "housing", label: "Housing", icon: House },
+      { key: "budget", label: "Budget", icon: PiggyBank },
+      { key: "activities", label: "Activities", icon: Binoculars },
+    ];
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.content}
+    >
+      {tabs.map(({ key, label, icon }) => (
+        <Chip
+          key={key}
+          label={label ?? ""}
+          icon={icon}
+          selected={activeTab === key}
+          onPress={() => onTabPress(key)}
+          variant="filled"
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    flexDirection: "row",
+    gap: Layout.spacing.xs,
+    paddingHorizontal: Layout.spacing.sm,
+  },
+});
+
+export default TripTabBar;

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -327,7 +327,6 @@ export default function Trip() {
   const createPollSheetRef = useRef<CreatePollSheetMethods>(null);
 
   const [locationDraft, setLocationDraft] = useState("");
-  const [locationText, setLocationText] = useState<string | null>(null);
 
   const { data: trip, isLoading } = useGetTrip(tripID!);
 
@@ -370,6 +369,9 @@ export default function Trip() {
   };
 
   const handleLocationPress = () => {
+    if (trip?.location) {
+      setLocationDraft(trip.location);
+    }
     locationSheetRef.current?.snapToIndex(0);
   };
 
@@ -381,11 +383,28 @@ export default function Trip() {
     }, []),
   );
 
-  const handleLocationConfirm = () => {
-    if (locationDraft.trim()) {
-      setLocationText(locationDraft.trim());
+  const handleLocationConfirm = async () => {
+    const trimmedLocation = locationDraft.trim();
+    if (!trimmedLocation) {
+      locationSheetRef.current?.close();
+      return;
     }
-    locationSheetRef.current?.close();
+
+    try {
+      await updateTripMutation.mutateAsync({
+        tripID: tripID!,
+        data: {
+          location: trimmedLocation,
+        },
+      });
+      await queryClient.invalidateQueries({
+        queryKey: getTripQueryKey(tripID!),
+      });
+    } catch {
+      // non-blocking
+    } finally {
+      locationSheetRef.current?.close();
+    }
   };
 
   const handleVoteOnDestination = () => {
@@ -499,7 +518,7 @@ export default function Trip() {
                   <Box flexDirection="row" alignItems="center" gap="xs">
                     <MapPin size={16} color={ColorPalette.gray500} />
                     <Text variant="bodySmDefault" color="gray500">
-                      {locationText ?? "Add location"}
+                      {trip?.location ?? "Add location"}
                     </Text>
                   </Box>
                 </Pressable>

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -62,10 +62,6 @@ export default function Trip() {
     query: { enabled: !!tripID },
   });
 
-  if (!tripID) {
-    return null;
-  }
-
   const handleTabPress = (tab: TabKey) => {
     if (tab === "settings") {
       router.push(`/trips/${tripID}/settings` as any);
@@ -122,7 +118,7 @@ export default function Trip() {
         tripID: tripID,
         data: {
           location: destination,
-        },
+        } as any, // TODO: Regenerate types after backend location field is added
       });
       await queryClient.invalidateQueries({
         queryKey: getTripQueryKey(tripID),
@@ -141,6 +137,10 @@ export default function Trip() {
   };
 
   const tripDate = formatTripDates(trip?.start_date, trip?.end_date);
+
+  if (!tripID) {
+    return null;
+  }
 
   return (
     <View style={styles.container}>
@@ -177,7 +177,7 @@ export default function Trip() {
             <TripMetadata
               tripName={trip?.name}
               tripDate={tripDate}
-              tripLocation={trip?.location}
+              tripLocation={(trip as any)?.location}
               isLoading={isLoading}
               onInviteFriends={shareInvite}
               onSettingsPress={() => router.push(`/trips/${tripID}/settings` as any)}

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -12,7 +12,8 @@ import CreatePollSheet, {
   CreatePollSheetMethods,
 } from "@/app/(app)/trips/[id]/polls/components/create-poll-sheet";
 import PollsTabContent from "@/app/(app)/trips/[id]/polls/components/polls-tab-content";
-import { Box } from "@/design-system";
+import { BackButton } from "@/design-system/components/navigation/arrow";
+import { Box, Text } from "@/design-system";
 import type { DateRange } from "@/design-system/primitives/date-picker";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
@@ -25,8 +26,9 @@ import {
   useFocusEffect,
   useLocalSearchParams,
 } from "expo-router";
+import { Map } from "lucide-react-native";
 import { useCallback, useRef, useState } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -140,12 +142,31 @@ export default function Trip() {
     <View style={styles.container}>
       <Stack.Screen options={{ headerShown: false }} />
 
-      <TripHeader
-        coverImageUrl={trip?.cover_image_url}
-        onMapPress={() => router.push(`/trips/${tripID}/search-location` as any)}
-      />
+      <TripHeader coverImageUrl={trip?.cover_image_url} />
 
       <SafeAreaView style={styles.safeArea} edges={["top"]}>
+        <Box
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          paddingHorizontal="sm"
+          paddingVertical="xs"
+        >
+          <BackButton />
+
+          <Pressable
+            onPress={() => router.push(`/trips/${tripID}/search-location` as any)}
+            style={styles.mapButton}
+            accessibilityRole="button"
+            accessibilityLabel="View map"
+          >
+            <Map size={16} color={ColorPalette.gray950} />
+            <Text variant="bodySmMedium" color="gray950">
+              Map
+            </Text>
+          </Pressable>
+        </Box>
+
         <Box style={styles.card}>
           <ScrollView
             showsVerticalScrollIndicator={false}
@@ -210,6 +231,20 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
     backgroundColor: "transparent",
+  },
+  mapButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: Layout.spacing.xxs,
+    backgroundColor: ColorPalette.white,
+    paddingHorizontal: Layout.spacing.sm,
+    paddingVertical: Layout.spacing.xxs,
+    borderRadius: CornerRadius.full,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
   },
   card: {
     flex: 1,

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -51,14 +51,20 @@ function formatTripDates(startDate?: string, endDate?: string): string | null {
 export default function Trip() {
   const { id: tripID } = useLocalSearchParams<{ id: string }>();
   const [activeTab, setActiveTab] = useState<TabKey>(INITIAL_TAB);
-  const { shareInvite } = useShareTripInvite(tripID!);
+  const { shareInvite } = useShareTripInvite(tripID ?? "");
   const updateTripMutation = useUpdateTrip();
   const queryClient = useQueryClient();
   const dateSheetRef = useRef<any>(null);
   const locationSheetRef = useRef<any>(null);
   const createPollSheetRef = useRef<CreatePollSheetMethods>(null);
 
-  const { data: trip, isLoading } = useGetTrip(tripID!);
+  const { data: trip, isLoading } = useGetTrip(tripID ?? "", {
+    query: { enabled: !!tripID },
+  });
+
+  if (!tripID) {
+    return null;
+  }
 
   const handleTabPress = (tab: TabKey) => {
     if (tab === "settings") {
@@ -74,7 +80,7 @@ export default function Trip() {
 
   const handlePollCreated = useCallback(() => {
     queryClient.invalidateQueries({
-      queryKey: getPollsByTripIDQueryKey(tripID!),
+      queryKey: getPollsByTripIDQueryKey(tripID),
     });
   }, [queryClient, tripID]);
 
@@ -82,14 +88,14 @@ export default function Trip() {
     if (!range.start) return;
     try {
       await updateTripMutation.mutateAsync({
-        tripID: tripID!,
+        tripID: tripID,
         data: {
           start_date: range.start.toISOString(),
           ...(range.end ? { end_date: range.end.toISOString() } : {}),
         },
       });
       await queryClient.invalidateQueries({
-        queryKey: getTripQueryKey(tripID!),
+        queryKey: getTripQueryKey(tripID),
       });
     } catch {
       // non-blocking
@@ -113,16 +119,17 @@ export default function Trip() {
   const handleSetLocation = async (destination: string) => {
     try {
       await updateTripMutation.mutateAsync({
-        tripID: tripID!,
+        tripID: tripID,
         data: {
           location: destination,
         },
       });
       await queryClient.invalidateQueries({
-        queryKey: getTripQueryKey(tripID!),
+        queryKey: getTripQueryKey(tripID),
       });
-    } catch {
-      // non-blocking
+    } catch (error) {
+      console.error("Failed to update trip location:", error);
+      // TODO: Show error toast to user
     } finally {
       locationSheetRef.current?.close();
     }
@@ -184,17 +191,17 @@ export default function Trip() {
 
             <Box paddingHorizontal="sm" paddingTop="sm" paddingBottom="xl">
               {activeTab === "itinerary" && <ItineraryEmptyState />}
-              {activeTab === "polls" && <PollsTabContent tripId={tripID!} />}
+              {activeTab === "polls" && <PollsTabContent tripId={tripID} />}
             </Box>
           </ScrollView>
         </Box>
       </SafeAreaView>
 
-      <CreateFAB tripID={tripID!} onCreatePoll={handleOpenCreatePoll} />
+      <CreateFAB tripID={tripID} onCreatePoll={handleOpenCreatePoll} />
 
       <CreatePollSheet
         ref={createPollSheetRef}
-        tripID={tripID!}
+        tripID={tripID}
         onCreated={handlePollCreated}
       />
 

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -7,7 +7,9 @@ import CreateFAB from "@/app/(app)/trips/[id]/components/create-fab";
 import ItineraryEmptyState from "@/app/(app)/trips/[id]/components/itinerary-empty-state";
 import TripHeader from "@/app/(app)/trips/[id]/components/trip-header";
 import TripMetadata from "@/app/(app)/trips/[id]/components/trip-metadata";
-import TripTabBar, { type TabKey } from "@/app/(app)/trips/[id]/components/trip-tab-bar";
+import TripTabBar, {
+  type TabKey,
+} from "@/app/(app)/trips/[id]/components/trip-tab-bar";
 import CreatePollSheet, {
   CreatePollSheetMethods,
 } from "@/app/(app)/trips/[id]/polls/components/create-poll-sheet";
@@ -20,11 +22,7 @@ import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
 import { useShareTripInvite } from "@/hooks/useShareTripInvite";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  router,
-  useFocusEffect,
-  useLocalSearchParams,
-} from "expo-router";
+import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
 import { Map } from "lucide-react-native";
 import { useCallback, useRef, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, View } from "react-native";
@@ -157,7 +155,9 @@ export default function Trip() {
           <BackButton />
 
           <Pressable
-            onPress={() => router.push(`/trips/${tripID}/search-location` as any)}
+            onPress={() =>
+              router.push(`/trips/${tripID}/search-location` as any)
+            }
             style={styles.mapButton}
             accessibilityRole="button"
             accessibilityLabel="View map"
@@ -180,7 +180,9 @@ export default function Trip() {
               tripLocation={(trip as any)?.location}
               isLoading={isLoading}
               onInviteFriends={shareInvite}
-              onSettingsPress={() => router.push(`/trips/${tripID}/settings` as any)}
+              onSettingsPress={() =>
+                router.push(`/trips/${tripID}/settings` as any)
+              }
               onDatePress={() => dateSheetRef.current?.snapToIndex(0)}
               onLocationPress={handleLocationPress}
             />

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -6,6 +6,7 @@ import { useGetRankPollResults } from "@/api/polls/useGetRankPollResults";
 import { getTripQueryKey, useGetTrip } from "@/api/trips/useGetTrip";
 import { useUpdateTrip } from "@/api/trips/useUpdateTrip";
 import { TripReminderDateSheet } from "@/app/(app)/components/trip-reminder-date-sheet";
+import { TripReminderLocationSheet } from "@/app/(app)/components/trip-reminder-location-sheet";
 import CreateFAB from "@/app/(app)/trips/[id]/components/create-fab";
 import CreatePollSheet, {
   CreatePollSheetMethods,
@@ -13,13 +14,10 @@ import CreatePollSheet, {
 import RankPollCard from "@/app/(app)/trips/[id]/polls/components/rank-poll-card";
 import VotePollCard from "@/app/(app)/trips/[id]/polls/components/vote-poll-card";
 import {
-  BottomSheet,
   Box,
-  Button,
   Chip,
   ErrorState,
   Text,
-  TextField,
 } from "@/design-system";
 import { BackButton } from "@/design-system/components/navigation/arrow";
 import type { DateRange } from "@/design-system/primitives/date-picker";
@@ -150,62 +148,6 @@ function ItineraryEmptyState() {
   );
 }
 
-// ─── Location sheet ───────────────────────────────────────────────────────────
-
-type LocationOptionsSheetProps = {
-  bottomSheetRef: React.RefObject<any>;
-  locationDraft: string;
-  onLocationDraftChange: (text: string) => void;
-  onLocationConfirm: () => void;
-  onVoteOnDestination: () => void;
-  onDismiss: () => void;
-};
-
-function LocationOptionsSheet({
-  bottomSheetRef,
-  locationDraft,
-  onLocationDraftChange,
-  onLocationConfirm,
-  onVoteOnDestination,
-  onDismiss,
-}: LocationOptionsSheetProps) {
-  return (
-    <BottomSheet ref={bottomSheetRef} snapPoints={["45%"]} onClose={onDismiss}>
-      <Box paddingHorizontal="sm" paddingTop="sm" paddingBottom="lg" gap="md">
-        <Box gap="xxs">
-          <Text variant="headingMd" color="gray950">
-            Where are you going?
-          </Text>
-          <Text variant="bodyDefault" color="gray500">
-            Set your trip destination
-          </Text>
-        </Box>
-        <Box gap="sm">
-          <TextField
-            value={locationDraft}
-            onChangeText={onLocationDraftChange}
-            placeholder="e.g. Paris, France"
-            returnKeyType="done"
-            onSubmitEditing={onLocationConfirm}
-          />
-          <Button
-            layout="textOnly"
-            label="Set Location"
-            variant="Primary"
-            onPress={onLocationConfirm}
-          />
-          <Button
-            layout="textOnly"
-            label="Vote on a Destination"
-            variant="Secondary"
-            onPress={onVoteOnDestination}
-          />
-        </Box>
-      </Box>
-    </BottomSheet>
-  );
-}
-
 // ─── Polls tab ────────────────────────────────────────────────────────────────
 
 function RankPollRow({
@@ -326,8 +268,6 @@ export default function Trip() {
   const locationSheetRef = useRef<any>(null);
   const createPollSheetRef = useRef<CreatePollSheetMethods>(null);
 
-  const [locationDraft, setLocationDraft] = useState("");
-
   const { data: trip, isLoading } = useGetTrip(tripID!);
 
   const handleTabPress = (tab: TabKey) => {
@@ -369,9 +309,6 @@ export default function Trip() {
   };
 
   const handleLocationPress = () => {
-    if (trip?.location) {
-      setLocationDraft(trip.location);
-    }
     locationSheetRef.current?.snapToIndex(0);
   };
 
@@ -383,18 +320,12 @@ export default function Trip() {
     }, []),
   );
 
-  const handleLocationConfirm = async () => {
-    const trimmedLocation = locationDraft.trim();
-    if (!trimmedLocation) {
-      locationSheetRef.current?.close();
-      return;
-    }
-
+  const handleSetLocation = async (destination: string) => {
     try {
       await updateTripMutation.mutateAsync({
         tripID: tripID!,
         data: {
-          location: trimmedLocation,
+          location: destination,
         },
       });
       await queryClient.invalidateQueries({
@@ -407,7 +338,7 @@ export default function Trip() {
     }
   };
 
-  const handleVoteOnDestination = () => {
+  const handleVoteOnLocation = () => {
     locationSheetRef.current?.close();
     router.push(`/trips/${tripID}/pitches` as any);
   };
@@ -553,12 +484,10 @@ export default function Trip() {
         onDismiss={() => dateSheetRef.current?.close()}
       />
 
-      <LocationOptionsSheet
+      <TripReminderLocationSheet
         bottomSheetRef={locationSheetRef}
-        locationDraft={locationDraft}
-        onLocationDraftChange={setLocationDraft}
-        onLocationConfirm={handleLocationConfirm}
-        onVoteOnDestination={handleVoteOnDestination}
+        onSetLocation={handleSetLocation}
+        onVoteOnLocation={handleVoteOnLocation}
         onDismiss={() => locationSheetRef.current?.close()}
       />
     </View>

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -1,74 +1,38 @@
-import {
-  getPollsByTripIDQueryKey,
-  useGetPollsByTripID,
-} from "@/api/polls/useGetPollsByTripID";
-import { useGetRankPollResults } from "@/api/polls/useGetRankPollResults";
+import { getPollsByTripIDQueryKey } from "@/api/polls/useGetPollsByTripID";
 import { getTripQueryKey, useGetTrip } from "@/api/trips/useGetTrip";
 import { useUpdateTrip } from "@/api/trips/useUpdateTrip";
 import { TripReminderDateSheet } from "@/app/(app)/components/trip-reminder-date-sheet";
 import { TripReminderLocationSheet } from "@/app/(app)/components/trip-reminder-location-sheet";
 import CreateFAB from "@/app/(app)/trips/[id]/components/create-fab";
+import ItineraryEmptyState from "@/app/(app)/trips/[id]/components/itinerary-empty-state";
+import TripHeader from "@/app/(app)/trips/[id]/components/trip-header";
+import TripMetadata from "@/app/(app)/trips/[id]/components/trip-metadata";
+import TripTabBar, { type TabKey } from "@/app/(app)/trips/[id]/components/trip-tab-bar";
 import CreatePollSheet, {
   CreatePollSheetMethods,
 } from "@/app/(app)/trips/[id]/polls/components/create-poll-sheet";
-import RankPollCard from "@/app/(app)/trips/[id]/polls/components/rank-poll-card";
-import VotePollCard from "@/app/(app)/trips/[id]/polls/components/vote-poll-card";
-import {
-  Box,
-  Chip,
-  ErrorState,
-  Text,
-} from "@/design-system";
-import { BackButton } from "@/design-system/components/navigation/arrow";
+import PollsTabContent from "@/app/(app)/trips/[id]/polls/components/polls-tab-content";
+import { Box } from "@/design-system";
 import type { DateRange } from "@/design-system/primitives/date-picker";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
-import { ModelsPollAPIResponse } from "@/types/types.gen";
-import { useQueryClient } from "@tanstack/react-query";
-import { Image } from "expo-image";
 import { useShareTripInvite } from "@/hooks/useShareTripInvite";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   router,
   Stack,
   useFocusEffect,
   useLocalSearchParams,
 } from "expo-router";
-import {
-  BellDot,
-  Binoculars,
-  Calendar,
-  ChartColumnBig,
-  House,
-  List,
-  Map,
-  MapPin,
-  PiggyBank,
-  Settings,
-  type LucideIcon,
-} from "lucide-react-native";
 import { useCallback, useRef, useState } from "react";
-import {
-  ActivityIndicator,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  View,
-} from "react-native";
+import { ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-type TabKey =
-  | "new"
-  | "itinerary"
-  | "polls"
-  | "housing"
-  | "budget"
-  | "activities"
-  | "settings";
-
 const INITIAL_TAB: TabKey = "itinerary";
+const CARD_TOP_OFFSET = 120;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -79,179 +43,6 @@ function formatTripDates(startDate?: string, endDate?: string): string | null {
   if (!endDate) return start;
   const end = new Date(endDate).toLocaleDateString("en-US", opts);
   return `${start} – ${end}`;
-}
-
-// ─── Sub-components ───────────────────────────────────────────────────────────
-
-function InviteFriendsButton({
-  onPress,
-  loading,
-}: {
-  onPress: () => void;
-  loading: boolean;
-}) {
-  if (loading) {
-    return <ActivityIndicator size="small" color={ColorPalette.gray500} />;
-  }
-  return <Chip label="+ Invite Friends" onPress={onPress} />;
-}
-
-type TripTabBarProps = {
-  activeTab: TabKey;
-  onTabPress: (tab: TabKey) => void;
-};
-
-function TripTabBar({ activeTab, onTabPress }: TripTabBarProps) {
-  const tabs: { key: TabKey; label?: string; icon: LucideIcon | undefined }[] =
-    [
-      { key: "new", label: "New", icon: BellDot },
-      { key: "itinerary", label: "Itinerary", icon: List },
-      { key: "polls", label: "Polls", icon: ChartColumnBig },
-      { key: "housing", label: "Housing", icon: House },
-      { key: "budget", label: "Budget", icon: PiggyBank },
-      { key: "activities", label: "Activities", icon: Binoculars },
-    ];
-
-  return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      contentContainerStyle={styles.tabBarContent}
-    >
-      {tabs.map(({ key, label, icon }) => (
-        <Chip
-          key={key}
-          label={label ?? ""}
-          icon={icon}
-          selected={activeTab === key}
-          onPress={() => onTabPress(key)}
-          variant="filled"
-        />
-      ))}
-    </ScrollView>
-  );
-}
-
-function ItineraryEmptyState() {
-  return (
-    <Box borderWidth={1} borderColor="gray200" borderRadius="xl" padding="sm">
-      <Box alignItems="center" paddingVertical="lg">
-        <Text
-          variant="bodySmDefault"
-          color="gray950"
-          style={styles.emptyStateText}
-        >
-          No activites planned. Get planning!
-        </Text>
-      </Box>
-    </Box>
-  );
-}
-
-// ─── Polls tab ────────────────────────────────────────────────────────────────
-
-function RankPollRow({
-  poll,
-  tripId,
-  onRanked,
-}: {
-  poll: ModelsPollAPIResponse;
-  tripId: string;
-  onRanked: () => void;
-}) {
-  const { data, isLoading, isError, refetch } = useGetRankPollResults(
-    tripId,
-    poll.id ?? "",
-    { query: { enabled: !!(tripId && poll.id) } },
-  );
-
-  if (isLoading) {
-    return (
-      <Box
-        backgroundColor="white"
-        borderRadius="md"
-        alignItems="center"
-        padding="lg"
-        style={styles.loadingCard}
-      >
-        <ActivityIndicator color={ColorPalette.brand500} />
-      </Box>
-    );
-  }
-  if (isError) {
-    return (
-      <Box backgroundColor="white" borderRadius="md" style={styles.loadingCard}>
-        <ErrorState title="Couldn't load poll" refresh={refetch} />
-      </Box>
-    );
-  }
-  if (!data) return null;
-  return <RankPollCard poll={data} tripId={tripId} onRanked={onRanked} />;
-}
-
-function PollsTabContent({ tripId }: { tripId: string }) {
-  const {
-    data: pollsData,
-    isLoading,
-    isError,
-    refetch,
-  } = useGetPollsByTripID(tripId, {}, { query: { enabled: !!tripId } });
-
-  const polls = pollsData?.items ?? [];
-  const votePolls = polls.filter((p) => p.poll_type !== "rank");
-  const rankPolls = polls.filter((p) => p.poll_type === "rank");
-
-  const handleVoted = useCallback(() => refetch(), [refetch]);
-  const handleRanked = useCallback(() => refetch(), [refetch]);
-
-  if (isLoading) {
-    return (
-      <Box alignItems="center" paddingVertical="xl">
-        <ActivityIndicator color={ColorPalette.brand500} />
-      </Box>
-    );
-  }
-
-  if (isError) {
-    return <ErrorState title="Couldn't load polls" />;
-  }
-
-  if (polls.length === 0) {
-    return (
-      <Box borderWidth={1} borderColor="gray200" borderRadius="xl" padding="sm">
-        <Box alignItems="center" paddingVertical="lg">
-          <Text
-            variant="bodyDefault"
-            color="gray950"
-            style={styles.emptyStateText}
-          >
-            No polls yet. Create one!
-          </Text>
-        </Box>
-      </Box>
-    );
-  }
-
-  return (
-    <Box gap="sm">
-      {votePolls.map((poll) => (
-        <VotePollCard
-          key={poll.id}
-          poll={poll}
-          tripId={tripId}
-          onVoted={handleVoted}
-        />
-      ))}
-      {rankPolls.map((poll) => (
-        <RankPollRow
-          key={poll.id}
-          poll={poll}
-          tripId={tripId}
-          onRanked={handleRanked}
-        />
-      ))}
-    </Box>
-  );
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -349,118 +140,33 @@ export default function Trip() {
     <View style={styles.container}>
       <Stack.Screen options={{ headerShown: false }} />
 
-      {trip?.cover_image_url ? (
-        <Image
-          source={{ uri: trip.cover_image_url }}
-          style={styles.coverImage}
-          contentFit="cover"
-        />
-      ) : (
-        <View style={[styles.coverImage, styles.coverImageFallback]} />
-      )}
+      <TripHeader
+        coverImageUrl={trip?.cover_image_url}
+        onMapPress={() => router.push(`/trips/${tripID}/search-location` as any)}
+      />
 
       <SafeAreaView style={styles.safeArea} edges={["top"]}>
-        <Box
-          flexDirection="row"
-          justifyContent="space-between"
-          alignItems="center"
-          paddingHorizontal="sm"
-          paddingVertical="xs"
-        >
-          <BackButton />
-
-          <Pressable
-            onPress={() =>
-              router.push(`/trips/${tripID}/search-location` as any)
-            }
-            style={styles.mapButton}
-            accessibilityRole="button"
-            accessibilityLabel="View map"
-          >
-            <Map size={16} color={ColorPalette.gray950} />
-            <Text variant="bodySmMedium" color="gray950">
-              Map
-            </Text>
-          </Pressable>
-        </Box>
-
         <Box style={styles.card}>
           <ScrollView
             showsVerticalScrollIndicator={false}
             contentContainerStyle={styles.scrollContent}
           >
-            <Box gap="xs" paddingHorizontal="sm" paddingTop="sm">
-              <Box
-                flexDirection="row"
-                alignItems="center"
-                justifyContent="space-between"
-              >
-                {isLoading ? (
-                  <Box
-                    width={160}
-                    height={28}
-                    backgroundColor="gray100"
-                    borderRadius="xs"
-                  />
-                ) : (
-                  <Text variant="headingMd" color="gray950">
-                    {trip?.name ?? "Trip"}
-                  </Text>
-                )}
-
-                <Box flexDirection="row" alignItems="center" gap="sm">
-                  <InviteFriendsButton
-                    onPress={shareInvite}
-                    loading={isInvitePending}
-                  />
-                  <Pressable
-                    onPress={() =>
-                      router.push(`/trips/${tripID}/settings` as any)
-                    }
-                    hitSlop={styles.hitSlop}
-                    accessibilityRole="button"
-                    accessibilityLabel="Trip settings"
-                  >
-                    <Settings size={20} color={ColorPalette.gray950} />
-                  </Pressable>
-                </Box>
-              </Box>
-
-              <Box gap="xs">
-                <Pressable
-                  onPress={() => dateSheetRef.current?.snapToIndex(0)}
-                  style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-                  accessibilityRole="button"
-                  accessibilityLabel="Set trip dates"
-                >
-                  <Box flexDirection="row" alignItems="center" gap="xs">
-                    <Calendar size={16} color={ColorPalette.gray500} />
-                    <Text variant="bodySmDefault" color="gray500">
-                      {tripDate ?? "Add dates"}
-                    </Text>
-                  </Box>
-                </Pressable>
-                <Pressable
-                  onPress={handleLocationPress}
-                  style={({ pressed }) => ({ opacity: pressed ? 0.6 : 1 })}
-                  accessibilityRole="button"
-                  accessibilityLabel="Set trip location"
-                >
-                  <Box flexDirection="row" alignItems="center" gap="xs">
-                    <MapPin size={16} color={ColorPalette.gray500} />
-                    <Text variant="bodySmDefault" color="gray500">
-                      {trip?.location ?? "Add location"}
-                    </Text>
-                  </Box>
-                </Pressable>
-              </Box>
-            </Box>
+            <TripMetadata
+              tripName={trip?.name}
+              tripDate={tripDate}
+              tripLocation={trip?.location}
+              isLoading={isLoading}
+              isInvitePending={isInvitePending}
+              onInviteFriends={shareInvite}
+              onSettingsPress={() => router.push(`/trips/${tripID}/settings` as any)}
+              onDatePress={() => dateSheetRef.current?.snapToIndex(0)}
+              onLocationPress={handleLocationPress}
+            />
 
             <Box paddingTop="sm">
               <TripTabBar activeTab={activeTab} onTabPress={handleTabPress} />
             </Box>
 
-            {/* Tab content */}
             <Box paddingHorizontal="sm" paddingTop="sm" paddingBottom="xl">
               {activeTab === "itinerary" && <ItineraryEmptyState />}
               {activeTab === "polls" && <PollsTabContent tripId={tripID!} />}
@@ -501,57 +207,19 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: ColorPalette.gray950,
   },
-  coverImage: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 260,
-  },
-  coverImageFallback: {
-    backgroundColor: ColorPalette.gray100,
-  },
   safeArea: {
     flex: 1,
     backgroundColor: "transparent",
   },
-  mapButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: Layout.spacing.xxs,
-    backgroundColor: ColorPalette.white,
-    paddingHorizontal: Layout.spacing.sm,
-    paddingVertical: Layout.spacing.xxs,
-    borderRadius: CornerRadius.full,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2,
-  },
   card: {
     flex: 1,
     backgroundColor: ColorPalette.white,
-    borderTopLeftRadius: 30,
-    borderTopRightRadius: 30,
+    borderTopLeftRadius: CornerRadius.xl,
+    borderTopRightRadius: CornerRadius.xl,
     overflow: "hidden",
-    marginTop: 120,
+    marginTop: CARD_TOP_OFFSET,
   },
   scrollContent: {
     paddingBottom: Layout.spacing.xl,
-    gap: 0,
   },
-  tabBarContent: {
-    flexDirection: "row",
-    gap: Layout.spacing.xs,
-    paddingHorizontal: Layout.spacing.sm,
-  },
-  emptyStateText: {
-    fontStyle: "italic",
-  },
-  loadingCard: {
-    borderWidth: 1,
-    borderColor: ColorPalette.gray100,
-  },
-  hitSlop: { top: 8, bottom: 8, left: 8, right: 8 },
 });

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -22,7 +22,6 @@ import { useShareTripInvite } from "@/hooks/useShareTripInvite";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   router,
-  Stack,
   useFocusEffect,
   useLocalSearchParams,
 } from "expo-router";
@@ -52,9 +51,7 @@ function formatTripDates(startDate?: string, endDate?: string): string | null {
 export default function Trip() {
   const { id: tripID } = useLocalSearchParams<{ id: string }>();
   const [activeTab, setActiveTab] = useState<TabKey>(INITIAL_TAB);
-  const { shareInvite, isPending: isInvitePending } = useShareTripInvite(
-    tripID!,
-  );
+  const { shareInvite } = useShareTripInvite(tripID!);
   const updateTripMutation = useUpdateTrip();
   const queryClient = useQueryClient();
   const dateSheetRef = useRef<any>(null);
@@ -140,8 +137,6 @@ export default function Trip() {
 
   return (
     <View style={styles.container}>
-      <Stack.Screen options={{ headerShown: false }} />
-
       <TripHeader coverImageUrl={trip?.cover_image_url} />
 
       <SafeAreaView style={styles.safeArea} edges={["top"]}>
@@ -177,7 +172,6 @@ export default function Trip() {
               tripDate={tripDate}
               tripLocation={trip?.location}
               isLoading={isLoading}
-              isInvitePending={isInvitePending}
               onInviteFriends={shareInvite}
               onSettingsPress={() => router.push(`/trips/${tripID}/settings` as any)}
               onDatePress={() => dateSheetRef.current?.snapToIndex(0)}

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -49,6 +49,7 @@ function formatTripDates(startDate?: string, endDate?: string): string | null {
 export default function Trip() {
   const { id: tripID } = useLocalSearchParams<{ id: string }>();
   const [activeTab, setActiveTab] = useState<TabKey>(INITIAL_TAB);
+  const [dateSheetError, setDateSheetError] = useState<string | null>(null);
   const { shareInvite } = useShareTripInvite(tripID ?? "");
   const updateTripMutation = useUpdateTrip();
   const queryClient = useQueryClient();
@@ -80,6 +81,7 @@ export default function Trip() {
 
   const handleDateSet = async (range: DateRange) => {
     if (!range.start) return;
+    setDateSheetError(null);
     try {
       await updateTripMutation.mutateAsync({
         tripID: tripID,
@@ -91,10 +93,9 @@ export default function Trip() {
       await queryClient.invalidateQueries({
         queryKey: getTripQueryKey(tripID),
       });
-    } catch {
-      // non-blocking
-    } finally {
       dateSheetRef.current?.close();
+    } catch {
+      setDateSheetError("Could not update trip dates. Please try again.");
     }
   };
 
@@ -212,6 +213,7 @@ export default function Trip() {
         onSetDate={handleDateSet}
         onSkip={() => dateSheetRef.current?.close()}
         onDismiss={() => dateSheetRef.current?.close()}
+        error={dateSheetError}
       />
 
       <TripReminderLocationSheet

--- a/frontend/app/(app)/trips/[id]/polls/components/polls-tab-content.tsx
+++ b/frontend/app/(app)/trips/[id]/polls/components/polls-tab-content.tsx
@@ -38,7 +38,7 @@ export function PollsTabContent({ tripId }: PollsTabContentProps) {
   }
 
   if (isError) {
-    return <ErrorState title="Couldn't load polls" />;
+    return <ErrorState title="Couldn't load polls" refresh={refetch} />;
   }
 
   if (polls.length === 0) {
@@ -59,17 +59,17 @@ export function PollsTabContent({ tripId }: PollsTabContentProps) {
 
   return (
     <Box gap="sm">
-      {votePolls.map((poll) => (
+      {votePolls.map((poll, index) => (
         <VotePollCard
-          key={poll.id}
+          key={poll.id ?? `vote-poll-${index}`}
           poll={poll}
           tripId={tripId}
           onVoted={handleVoted}
         />
       ))}
-      {rankPolls.map((poll) => (
+      {rankPolls.map((poll, index) => (
         <RankPollRow
-          key={poll.id}
+          key={poll.id ?? `rank-poll-${index}`}
           poll={poll}
           tripId={tripId}
           onRanked={handleRanked}

--- a/frontend/app/(app)/trips/[id]/polls/components/polls-tab-content.tsx
+++ b/frontend/app/(app)/trips/[id]/polls/components/polls-tab-content.tsx
@@ -1,0 +1,90 @@
+import { useGetPollsByTripID } from "@/api/polls/useGetPollsByTripID";
+import { Box, ErrorState, Text } from "@/design-system";
+import { ColorPalette } from "@/design-system/tokens/color";
+import { useCallback } from "react";
+import { ActivityIndicator, StyleSheet } from "react-native";
+import RankPollRow from "./rank-poll-row";
+import VotePollCard from "./vote-poll-card";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type PollsTabContentProps = {
+  tripId: string;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function PollsTabContent({ tripId }: PollsTabContentProps) {
+  const {
+    data: pollsData,
+    isLoading,
+    isError,
+    refetch,
+  } = useGetPollsByTripID(tripId, {}, { query: { enabled: !!tripId } });
+
+  const polls = pollsData?.items ?? [];
+  const votePolls = polls.filter((p) => p.poll_type !== "rank");
+  const rankPolls = polls.filter((p) => p.poll_type === "rank");
+
+  const handleVoted = useCallback(() => refetch(), [refetch]);
+  const handleRanked = useCallback(() => refetch(), [refetch]);
+
+  if (isLoading) {
+    return (
+      <Box alignItems="center" paddingVertical="xl">
+        <ActivityIndicator color={ColorPalette.brand500} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState title="Couldn't load polls" />;
+  }
+
+  if (polls.length === 0) {
+    return (
+      <Box borderWidth={1} borderColor="gray200" borderRadius="xl" padding="sm">
+        <Box alignItems="center" paddingVertical="lg">
+          <Text
+            variant="bodyDefault"
+            color="gray950"
+            style={styles.emptyStateText}
+          >
+            No polls yet. Create one!
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box gap="sm">
+      {votePolls.map((poll) => (
+        <VotePollCard
+          key={poll.id}
+          poll={poll}
+          tripId={tripId}
+          onVoted={handleVoted}
+        />
+      ))}
+      {rankPolls.map((poll) => (
+        <RankPollRow
+          key={poll.id}
+          poll={poll}
+          tripId={tripId}
+          onRanked={handleRanked}
+        />
+      ))}
+    </Box>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  emptyStateText: {
+    fontStyle: "italic",
+  },
+});
+
+export default PollsTabContent;

--- a/frontend/app/(app)/trips/[id]/polls/components/rank-poll-row.tsx
+++ b/frontend/app/(app)/trips/[id]/polls/components/rank-poll-row.tsx
@@ -1,0 +1,61 @@
+import { useGetRankPollResults } from "@/api/polls/useGetRankPollResults";
+import { Box, ErrorState } from "@/design-system";
+import { ColorPalette } from "@/design-system/tokens/color";
+import { ModelsPollAPIResponse } from "@/types/types.gen";
+import { ActivityIndicator, StyleSheet } from "react-native";
+import RankPollCard from "./rank-poll-card";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type RankPollRowProps = {
+  poll: ModelsPollAPIResponse;
+  tripId: string;
+  onRanked: () => void;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function RankPollRow({ poll, tripId, onRanked }: RankPollRowProps) {
+  const { data, isLoading, isError, refetch } = useGetRankPollResults(
+    tripId,
+    poll.id ?? "",
+    { query: { enabled: !!(tripId && poll.id) } },
+  );
+
+  if (isLoading) {
+    return (
+      <Box
+        backgroundColor="white"
+        borderRadius="md"
+        alignItems="center"
+        padding="lg"
+        style={styles.loadingCard}
+      >
+        <ActivityIndicator color={ColorPalette.brand500} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Box backgroundColor="white" borderRadius="md" style={styles.loadingCard}>
+        <ErrorState title="Couldn't load poll" refresh={refetch} />
+      </Box>
+    );
+  }
+
+  if (!data) return null;
+
+  return <RankPollCard poll={data} tripId={tripId} onRanked={onRanked} />;
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  loadingCard: {
+    borderWidth: 1,
+    borderColor: ColorPalette.gray100,
+  },
+});
+
+export default RankPollRow;

--- a/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
+++ b/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
@@ -20,7 +20,15 @@ import { CornerRadius } from "../../tokens/corner-radius";
 
 export const InsideBottomSheetContext = createContext(false);
 
-type BottomSheetSize = "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "full";
+type BottomSheetSize =
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "full";
 
 const SIZE_MAP: Record<BottomSheetSize, string[]> = {
   xxs: ["25%"],
@@ -67,7 +75,7 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
 
     // Determine snapPoints: size prop takes precedence, then explicit snapPoints, then default
     const resolvedSnapPoints = useMemo(
-      () => (size ? SIZE_MAP[size] : snapPoints ?? ["80%", "95%"]),
+      () => (size ? SIZE_MAP[size] : (snapPoints ?? ["80%", "95%"])),
       [size, snapPoints],
     );
 

--- a/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
+++ b/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
@@ -16,6 +16,7 @@ import React, {
   useRef,
 } from "react";
 import { Keyboard, Platform } from "react-native";
+import { CornerRadius } from "../../tokens/corner-radius";
 
 export const InsideBottomSheetContext = createContext(false);
 
@@ -148,6 +149,10 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
           enableHandlePanningGesture={!disableClose}
           onClose={handleClose}
           style={{ flex: 1, zIndex: 9999 }}
+          backgroundStyle={{
+            borderTopLeftRadius: CornerRadius.xl,
+            borderTopRightRadius: CornerRadius.xl,
+          }}
         >
           <BottomSheetScrollView
             keyboardShouldPersistTaps="handled"

--- a/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
+++ b/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
@@ -12,15 +12,32 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from "react";
 import { Keyboard, Platform } from "react-native";
 
 export const InsideBottomSheetContext = createContext(false);
 
+type BottomSheetSize = "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "full";
+
+const SIZE_MAP: Record<BottomSheetSize, string[]> = {
+  xxs: ["25%"],
+  xs: ["33%"],
+  sm: ["40%"],
+  md: ["50%"],
+  lg: ["60%"],
+  xl: ["70%"],
+  xxl: ["80%"],
+  full: ["95%"],
+};
+
 interface BottomSheetModalProps {
   children: React.ReactNode;
   footer?: React.ReactNode;
+  /** Size variant - overrides snapPoints if provided */
+  size?: BottomSheetSize;
+  /** Custom snap points - ignored if size is provided */
   snapPoints?: (string | number)[];
   initialIndex?: number;
   onClose?: () => void;
@@ -36,7 +53,8 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
       onChange,
       children,
       footer,
-      snapPoints = ["80%", "95%"],
+      size,
+      snapPoints,
       initialIndex = -1,
       onClose,
       disableClose = false,
@@ -45,6 +63,12 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
   ) => {
     const innerRef = useRef<BottomSheet>(null);
     const currentIndex = useRef(initialIndex);
+
+    // Determine snapPoints: size prop takes precedence, then explicit snapPoints, then default
+    const resolvedSnapPoints = useMemo(
+      () => (size ? SIZE_MAP[size] : snapPoints ?? ["80%", "95%"]),
+      [size, snapPoints],
+    );
 
     useImperativeHandle(ref, () => ({
       snapToIndex: (...args: Parameters<BottomSheetMethods["snapToIndex"]>) =>
@@ -64,12 +88,12 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
 
     const handleChange = useCallback(
       (index: number) => {
-        if (index >= -1 && index <= snapPoints.length - 1) {
+        if (index >= -1 && index <= resolvedSnapPoints.length - 1) {
           currentIndex.current = index;
         }
         onChange?.(index);
       },
-      [onChange, snapPoints],
+      [onChange, resolvedSnapPoints],
     );
 
     useEffect(() => {
@@ -115,7 +139,7 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
         <BottomSheet
           ref={innerRef}
           index={initialIndex}
-          snapPoints={snapPoints}
+          snapPoints={resolvedSnapPoints}
           onChange={handleChange}
           backdropComponent={renderBackdrop}
           footerComponent={footer ? renderFooter : undefined}

--- a/frontend/design-system/components/buttons/button.tsx
+++ b/frontend/design-system/components/buttons/button.tsx
@@ -3,8 +3,8 @@ import { Text } from "@/design-system/primitives/text";
 import { ColorName } from "@/design-system/tokens/color";
 import { useTheme } from "@/design-system/tokens/theme";
 import { LucideProps } from "lucide-react-native";
-import React from "react";
-import { StyleProp, TouchableOpacity, ViewStyle } from "react-native";
+import React, { useMemo } from "react";
+import { Animated, Pressable, StyleProp, ViewStyle } from "react-native";
 import { ButtonSize, ButtonVariant, resolveButtonStyle } from "./variant";
 
 type LucideIconComponent = React.ComponentType<LucideProps>;
@@ -55,6 +55,27 @@ export const Button: React.FC<ButtonProps> = ({
     layoutProps.layout === "iconOnly"
       ? layoutProps.accessibilityLabel
       : layoutProps.label;
+
+  const scaleAnim = useMemo(() => new Animated.Value(1), []);
+
+  const handlePressIn = () => {
+    if (isDisabled) return;
+    Animated.spring(scaleAnim, {
+      toValue: 0.97,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 4,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 4,
+    }).start();
+  };
 
   const renderContent = () => {
     if (loading) {
@@ -121,41 +142,51 @@ export const Button: React.FC<ButtonProps> = ({
   };
 
   return (
-    <TouchableOpacity
-      onPress={onPress}
-      disabled={isDisabled}
-      activeOpacity={0.7}
-      accessible
-      accessibilityRole="button"
-      accessibilityLabel={loading ? "Loading" : a11yLabel}
-      accessibilityState={{ disabled: isDisabled, busy: loading }}
+    <Animated.View
+      style={{
+        transform: [{ scale: scaleAnim }],
+      }}
     >
-      <Box
-        flexDirection="row"
-        alignItems="center"
-        justifyContent="center"
-        alignSelf="stretch"
-        style={[
-          {
-            minHeight: resolved.minHeight,
-            paddingHorizontal: isIconOnly ? 0 : resolved.paddingHorizontal,
-            borderRadius: resolved.borderRadius,
-            borderWidth: resolved.borderWidth,
-            borderStyle: variant === "Dashed" ? "dashed" : "solid",
-            borderColor: resolved.borderColor
-              ? colors[resolved.borderColor as keyof typeof colors]
-              : undefined,
-            backgroundColor:
-              resolved.backgroundColor === "transparent"
-                ? "transparent"
-                : colors[resolved.backgroundColor as keyof typeof colors],
-            width: isIconOnly ? resolved.minHeight : "auto",
-          },
-          style,
-        ]}
+      <Pressable
+        onPress={onPress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={isDisabled}
+        accessible
+        accessibilityRole="button"
+        accessibilityLabel={loading ? "Loading" : a11yLabel}
+        accessibilityState={{ disabled: isDisabled, busy: loading }}
       >
-        {renderContent()}
-      </Box>
-    </TouchableOpacity>
+        {({ pressed }) => (
+          <Box
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="center"
+            alignSelf="stretch"
+            style={[
+              {
+                minHeight: resolved.minHeight,
+                paddingHorizontal: isIconOnly ? 0 : resolved.paddingHorizontal,
+                borderRadius: resolved.borderRadius,
+                borderWidth: resolved.borderWidth,
+                borderStyle: variant === "Dashed" ? "dashed" : "solid",
+                borderColor: resolved.borderColor
+                  ? colors[resolved.borderColor as keyof typeof colors]
+                  : undefined,
+                backgroundColor:
+                  resolved.backgroundColor === "transparent"
+                    ? "transparent"
+                    : colors[resolved.backgroundColor as keyof typeof colors],
+                width: isIconOnly ? resolved.minHeight : "auto",
+                opacity: isDisabled ? 0.5 : pressed ? 0.9 : 1,
+              },
+              style,
+            ]}
+          >
+            {renderContent()}
+          </Box>
+        )}
+      </Pressable>
+    </Animated.View>
   );
 };

--- a/frontend/design-system/components/buttons/button.tsx
+++ b/frontend/design-system/components/buttons/button.tsx
@@ -1,9 +1,10 @@
+import { usePressScale } from "@/design-system/hooks/usePressScale";
 import { Box } from "@/design-system/primitives/box";
 import { Text } from "@/design-system/primitives/text";
 import { ColorName } from "@/design-system/tokens/color";
 import { useTheme } from "@/design-system/tokens/theme";
 import { LucideProps } from "lucide-react-native";
-import React, { useMemo } from "react";
+import React from "react";
 import { Animated, Pressable, StyleProp, ViewStyle } from "react-native";
 import { ButtonSize, ButtonVariant, resolveButtonStyle } from "./variant";
 
@@ -56,26 +57,10 @@ export const Button: React.FC<ButtonProps> = ({
       ? layoutProps.accessibilityLabel
       : layoutProps.label;
 
-  const scaleAnim = useMemo(() => new Animated.Value(1), []);
-
-  const handlePressIn = () => {
-    if (isDisabled) return;
-    Animated.spring(scaleAnim, {
-      toValue: 0.97,
-      useNativeDriver: true,
-      speed: 50,
-      bounciness: 4,
-    }).start();
-  };
-
-  const handlePressOut = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 1,
-      useNativeDriver: true,
-      speed: 50,
-      bounciness: 4,
-    }).start();
-  };
+  const { scaleAnim, onPressIn, onPressOut } = usePressScale({
+    pressedScale: 0.97,
+    isDisabled,
+  });
 
   const renderContent = () => {
     if (loading) {
@@ -149,8 +134,8 @@ export const Button: React.FC<ButtonProps> = ({
     >
       <Pressable
         onPress={onPress}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
         disabled={isDisabled}
         accessible
         accessibilityRole="button"

--- a/frontend/design-system/components/buttons/chip.tsx
+++ b/frontend/design-system/components/buttons/chip.tsx
@@ -23,7 +23,7 @@ const VARIANT_STYLES = {
   outlined: {
     unselected: {
       backgroundColor: ColorPalette.white,
-      borderColor: ColorPalette.gray300,
+      borderColor: ColorPalette.gray100,
     },
     selected: {
       backgroundColor: ColorPalette.gray900,

--- a/frontend/design-system/components/buttons/chip.tsx
+++ b/frontend/design-system/components/buttons/chip.tsx
@@ -94,10 +94,7 @@ export default function Chip({
         })}
       >
         {Icon && <Icon size={16} color={iconColor} />}
-        <Text
-          variant={variantStyle.textVariant}
-          style={{ color: iconColor }}
-        >
+        <Text variant={variantStyle.textVariant} style={{ color: iconColor }}>
           {label}
         </Text>
       </Pressable>

--- a/frontend/design-system/components/buttons/chip.tsx
+++ b/frontend/design-system/components/buttons/chip.tsx
@@ -1,8 +1,8 @@
+import { usePressScale } from "@/design-system/hooks/usePressScale";
 import { Text } from "@/design-system/primitives/text";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { LucideIcon } from "lucide-react-native";
-import { useMemo } from "react";
 import { Animated, Pressable } from "react-native";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -63,25 +63,10 @@ export default function Chip({
     VARIANT_STYLES[variant][selected ? "selected" : "unselected"];
   const iconColor = selected ? ColorPalette.white : ColorPalette.gray900;
 
-  const scaleAnim = useMemo(() => new Animated.Value(1), []);
-
-  const handlePressIn = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 0.95,
-      useNativeDriver: true,
-      speed: 50,
-      bounciness: 4,
-    }).start();
-  };
-
-  const handlePressOut = () => {
-    Animated.spring(scaleAnim, {
-      toValue: 1,
-      useNativeDriver: true,
-      speed: 50,
-      bounciness: 4,
-    }).start();
-  };
+  const { scaleAnim, onPressIn, onPressOut } = usePressScale({
+    pressedScale: 0.95,
+    isDisabled: disabled,
+  });
 
   return (
     <Animated.View
@@ -91,8 +76,8 @@ export default function Chip({
     >
       <Pressable
         onPress={onPress}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
         disabled={disabled}
         style={({ pressed }) => ({
           flexDirection: "row",

--- a/frontend/design-system/components/buttons/chip.tsx
+++ b/frontend/design-system/components/buttons/chip.tsx
@@ -24,20 +24,28 @@ const VARIANT_STYLES = {
     unselected: {
       backgroundColor: ColorPalette.white,
       borderColor: ColorPalette.gray100,
+      textVariant: "bodyXsMedium",
+      cornerRadius: CornerRadius.full,
     },
     selected: {
       backgroundColor: ColorPalette.gray900,
       borderColor: "transparent",
+      textVariant: "bodyXsMedium",
+      cornerRadius: CornerRadius.full,
     },
   },
   filled: {
     unselected: {
       backgroundColor: ColorPalette.gray50,
       borderColor: "transparent",
+      textVariant: "bodySmMedium",
+      cornerRadius: CornerRadius.sm,
     },
     selected: {
       backgroundColor: ColorPalette.gray950,
       borderColor: "transparent",
+      textVariant: "bodySmMedium",
+      cornerRadius: CornerRadius.sm,
     },
   },
 } as const;
@@ -65,8 +73,7 @@ export default function Chip({
         paddingHorizontal: 12,
         paddingVertical: 6,
         borderWidth: 1,
-        borderRadius:
-          variant === "filled" ? CornerRadius.sm : CornerRadius.full,
+        borderRadius: variantStyle.cornerRadius,
         borderColor: variantStyle.borderColor,
         backgroundColor: variantStyle.backgroundColor,
         opacity: disabled ? 0.5 : 1,
@@ -75,7 +82,7 @@ export default function Chip({
     >
       {Icon && <Icon size={16} color={iconColor} />}
       <Text
-        variant={variant === "filled" ? "bodySmMedium" : "bodyXsMedium"}
+        variant={variantStyle.textVariant}
         style={{ color: iconColor }}
       >
         {label}

--- a/frontend/design-system/components/buttons/chip.tsx
+++ b/frontend/design-system/components/buttons/chip.tsx
@@ -2,7 +2,8 @@ import { Text } from "@/design-system/primitives/text";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { LucideIcon } from "lucide-react-native";
-import { Pressable } from "react-native";
+import { useMemo } from "react";
+import { Animated, Pressable } from "react-native";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -62,31 +63,59 @@ export default function Chip({
     VARIANT_STYLES[variant][selected ? "selected" : "unselected"];
   const iconColor = selected ? ColorPalette.white : ColorPalette.gray900;
 
+  const scaleAnim = useMemo(() => new Animated.Value(1), []);
+
+  const handlePressIn = () => {
+    Animated.spring(scaleAnim, {
+      toValue: 0.95,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 4,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 4,
+    }).start();
+  };
+
   return (
-    <Pressable
-      onPress={onPress}
-      disabled={disabled}
+    <Animated.View
       style={{
-        flexDirection: "row",
-        alignItems: "center",
-        gap: 4,
-        paddingHorizontal: 12,
-        paddingVertical: 6,
-        borderWidth: 1,
-        borderRadius: variantStyle.cornerRadius,
-        borderColor: variantStyle.borderColor,
-        backgroundColor: variantStyle.backgroundColor,
-        opacity: disabled ? 0.5 : 1,
-        overflow: "hidden",
+        transform: [{ scale: scaleAnim }],
       }}
     >
-      {Icon && <Icon size={16} color={iconColor} />}
-      <Text
-        variant={variantStyle.textVariant}
-        style={{ color: iconColor }}
+      <Pressable
+        onPress={onPress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={disabled}
+        style={({ pressed }) => ({
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 4,
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          borderWidth: 1,
+          borderRadius: variantStyle.cornerRadius,
+          borderColor: variantStyle.borderColor,
+          backgroundColor: variantStyle.backgroundColor,
+          opacity: disabled ? 0.5 : pressed ? 0.9 : 1,
+          overflow: "hidden",
+        })}
       >
-        {label}
-      </Text>
-    </Pressable>
+        {Icon && <Icon size={16} color={iconColor} />}
+        <Text
+          variant={variantStyle.textVariant}
+          style={{ color: iconColor }}
+        >
+          {label}
+        </Text>
+      </Pressable>
+    </Animated.View>
   );
 }

--- a/frontend/design-system/hooks/usePressScale.ts
+++ b/frontend/design-system/hooks/usePressScale.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo } from "react";
+import { Animated } from "react-native";
+
+type UsePressScaleOptions = {
+  /** Scale value when pressed (default: 0.95) */
+  pressedScale?: number;
+  /** Whether the button is disabled (default: false) */
+  isDisabled?: boolean;
+};
+
+/**
+ * Shared hook for press-scale animation logic used in Button and Chip components.
+ * Returns an animated value and press handlers for consistent scaling behavior.
+ */
+export function usePressScale({
+  pressedScale = 0.95,
+  isDisabled = false,
+}: UsePressScaleOptions = {}) {
+  const scaleAnim = useMemo(() => new Animated.Value(1), []);
+
+  const handlePressIn = useCallback(() => {
+    if (isDisabled) return;
+    Animated.spring(scaleAnim, {
+      toValue: pressedScale,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 4,
+    }).start();
+  }, [isDisabled, scaleAnim, pressedScale]);
+
+  const handlePressOut = useCallback(() => {
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      useNativeDriver: true,
+      speed: 50,
+      bounciness: 4,
+    }).start();
+  }, [scaleAnim]);
+
+  return {
+    scaleAnim,
+    onPressIn: handlePressIn,
+    onPressOut: handlePressOut,
+  };
+}

--- a/frontend/hooks/useShimmerAnimation.tsx
+++ b/frontend/hooks/useShimmerAnimation.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import {
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+
+/**
+ * Creates a shimmer animation that moves from left to right using Reanimated
+ * Returns a shared value that can be used to translate the shimmer gradient
+ */
+const useShimmerAnimation = (duration: number = 1500) => {
+  const translateX = useSharedValue(-1);
+
+  useEffect(() => {
+    translateX.value = withRepeat(
+      withTiming(1, { duration }),
+      -1, // infinite repeat
+      false, // don't reverse
+    );
+  }, [translateX, duration]);
+
+  return translateX;
+};
+
+export default useShimmerAnimation;


### PR DESCRIPTION
# Description

> [!NOTE]
> There hasn't been like autofilled/whatever functionality setting a location is. That's not fully flushed out in my head yet so it hasn't been implemented. The most important thing is that there's a column for it for now. Will have to confirm with design all the different ways location can be set

- added location to trips
- updated a bottom sheet to have size variance (to better match the figma)
- updated the recommended cards to match figma
- text updates here and there to match padding and font sizes from the figma
- added animations to chip and buttons
- added swipe-left gesture for back navigations from trips/id (reasoning is because the arrow is hard to spot when the banner is dark)
- refactored the trips/id components so that it's a little easier to read
- removed loading state from invite friends (it didn't really make sense to have a loading state)
- moved the header of the home screen into the actual homescreen content (so that swipe navigation actually makes sense)

https://github.com/user-attachments/assets/766817b9-1039-451f-8df5-818898cad50b


<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [x]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [x] New and existing tests pass locally with my changes.
* [x] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-Visible Changes
- Trips now include an optional location field surfaced across create, update, list and detail views.
- UI polish: updated home header placement, larger section headings, increased upcoming image height, refreshed recommended cards (padding, shadow, rotation), and larger corner radii.
- Interactive feedback: press-scale animations for buttons and chips and improved bottom-sheet sizing to match Figma.
- Navigation: enabled swipe-left (drag-right) back gesture on trip detail screens and adjusted header placement so gestures behave correctly.
- Trip detail refactor: trip header, metadata, tab bar, itinerary empty state and polls split into modular components; location can be set from metadata UI.

## Changes by Category

Features
- Add trip location field (DB migration, model, repository update, API responses, UI input and listing).
- Press-scale animations for Button and Chip components (spring-based scale).
- Swipe-back gesture support on trip detail screens.
- BottomSheet size variant mapping (xs/sm/md → snapPoints) and per-sheet size usage.
- New hook: useUploadTripCoverImage.

Improvements
- Refactored trip detail into TripHeader, TripMetadata, TripTabBar, ItineraryEmptyState, PollsTabContent, RankPollRow, Polls rendering components.
- Home screen header moved into content, added Create-trip icon button, section typography increased to headingXl.
- Recommended trips and hero cards: updated padding, image heights (140 → 170), shadow offsets, first-card rotation, and corner radii.
- Bottom sheet layouts reworked (size="xs", header row with space-between, hyphenated date range).
- Various text, padding, visual tweaks and removal of some loading states (invite flow).

Fixes
- Ensure swipe gestures behave correctly by moving header into content and enabling gestureEnabled on nested screens.
- Persist and surface empty-string and long-string location updates correctly (backend + tests).

Infra
- DB migration: add location VARCHAR(255) to trips (goose Up/Down).
- Tests: new trip location integration test coverage.

## Contribution Summary

| Area | Added lines | Removed lines | Net |
|------|-------------:|--------------:|----:|
| Backend (migrations, models, repository, services, tests) | 273 | 0 | +273 |
| Frontend (home, trip detail, design system, hooks, components) | 674 | 570 | +104 |
| **Total** | **947** | **570** | **+377** |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->