### PR TITLE
fixed date to show local time (had an issue where it didn't display t…

### DIFF
--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -35,13 +35,18 @@ const CARD_TOP_OFFSET = 120;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+function parseLocalDate(iso: string): Date {
+  const [year, month, day] = iso.split("T")[0]!.split("-").map(Number);
+  return new Date(year!, month! - 1, day!);
+}
+
 function formatTripDates(startDate?: string, endDate?: string): string | null {
   if (!startDate) return null;
   const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  const start = new Date(startDate).toLocaleDateString("en-US", opts);
+  const start = parseLocalDate(startDate).toLocaleDateString("en-US", opts);
   if (!endDate) return start;
-  const end = new Date(endDate).toLocaleDateString("en-US", opts);
-  return `${start} – ${end}`;
+  const end = parseLocalDate(endDate).toLocaleDateString("en-US", opts);
+  return `${start} - ${end}`;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/frontend/app/(app)/trips/[id]/index.tsx
+++ b/frontend/app/(app)/trips/[id]/index.tsx
@@ -21,6 +21,7 @@ import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
 import { useShareTripInvite } from "@/hooks/useShareTripInvite";
+import { formatTripDates } from "@/utils/date-helpers";
 import { useQueryClient } from "@tanstack/react-query";
 import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
 import { Map } from "lucide-react-native";
@@ -32,22 +33,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 const INITIAL_TAB: TabKey = "itinerary";
 const CARD_TOP_OFFSET = 120;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function parseLocalDate(iso: string): Date {
-  const [year, month, day] = iso.split("T")[0]!.split("-").map(Number);
-  return new Date(year!, month! - 1, day!);
-}
-
-function formatTripDates(startDate?: string, endDate?: string): string | null {
-  if (!startDate) return null;
-  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  const start = parseLocalDate(startDate).toLocaleDateString("en-US", opts);
-  if (!endDate) return start;
-  const end = parseLocalDate(endDate).toLocaleDateString("en-US", opts);
-  return `${start} - ${end}`;
-}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 

--- a/frontend/utils/date-helpers.ts
+++ b/frontend/utils/date-helpers.ts
@@ -1,0 +1,38 @@
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+};
+
+/**
+ * Parses an ISO date string (e.g. "2026-04-10" or "2026-04-10T00:00:00Z")
+ * into a local-timezone Date, avoiding the off-by-one bug that occurs when
+ * `new Date("YYYY-MM-DD")` is interpreted as UTC midnight.
+ */
+export function parseLocalDate(iso: string): Date {
+  const [year, month, day] = iso.split("T")[0]!.split("-").map(Number);
+  return new Date(year!, month! - 1, day!);
+}
+
+/**
+ * Formats a start/end ISO date pair into a human-readable range.
+ *
+ * Examples:
+ *  - ("2026-04-10")            → "Apr 10"
+ *  - ("2026-04-10", "2026-04-15") → "Apr 10 – Apr 15"
+ */
+export function formatTripDates(
+  startDate?: string,
+  endDate?: string,
+): string | null {
+  if (!startDate) return null;
+  const start = parseLocalDate(startDate).toLocaleDateString(
+    "en-US",
+    DATE_FORMAT_OPTIONS,
+  );
+  if (!endDate) return start;
+  const end = parseLocalDate(endDate).toLocaleDateString(
+    "en-US",
+    DATE_FORMAT_OPTIONS,
+  );
+  return `${start} - ${end}`;
+}


### PR DESCRIPTION
…he correct date but the day before our selected range

# Description
- the date selector used to display a day earlier than what we selected on the trips/id page. Fixed it
- refactored the date format helpers into its own utils
<img width="378" height="610" alt="Screenshot 2026-04-08 at 10 26 31 PM" src="https://github.com/user-attachments/assets/dadea24b-125a-478c-89e9-44e7796fd9e6" />

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Fixed date selector on trips/id page displaying the day before the selected date range
- Date selector now correctly shows local date instead of UTC-interpreted dates
- Centralized date formatting utilities for consistent date display across the application

## Changes by Category

**Fixes**
- Corrected local timezone handling in date parsing to prevent off-by-one day display issues
- Implemented `parseLocalDate()` to construct Date objects using local timezone components instead of UTC interpretation

**Improvements**
- Extracted date formatting logic into shared utility functions (`parseLocalDate`, `formatTripDates`)
- Standardized date range display format (short month/day format)

## Author Contribution

| File | Added | Removed |
|------|-------|---------|
| frontend/app/(app)/trips/[id]/index.tsx | 1 | 11 |
| frontend/utils/date-helpers.ts | 38 | 0 |
| **Total** | **39** | **11** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->