### PR TITLE
fix: home ui spacing nit

### DIFF
--- a/frontend/app/(app)/components/home/home-upcoming-empty-card.tsx
+++ b/frontend/app/(app)/components/home/home-upcoming-empty-card.tsx
@@ -18,14 +18,15 @@ export function HomeUpcomingEmptyCard({
       gap="sm"
       style={HOME_CARD_FLOATING_SHADOW}
     >
-      <Box alignItems="center" paddingVertical="md" gap="sm">
-        <Text variant="headingXl" color="gray900">
-          {"\uD83C\uDF0E"}
-        </Text>
+      <Box alignItems="center" paddingVertical="md" gap="xxs">
+        <Text style={{ fontSize: 48, lineHeight: 64 }}>🌎</Text>
         <Text
           variant="bodySmDefault"
           color="gray900"
-          style={{ fontStyle: "italic", textAlign: "center" }}
+          style={{
+            textAlign: "center",
+            fontFamily: "Figtree-Italic",
+          }}
         >
           No upcoming trips. Get planning!
         </Text>

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -422,21 +422,14 @@ export default function HomeScreen() {
                   paddingBottom="lg"
                   gap="sm"
                 >
-                  {tripsQueryEnabled && tripsQuery.isPending ? (
-                    <SkeletonRect
-                      width="full"
-                      borderRadius="lg"
-                      style={{ height: 260 }}
-                    />
-                  ) : null}
                   {tripsQueryEnabled && tripsQuery.isError ? (
                     <ErrorState
-                      title="Couldn’t load trips"
+                      title="Couldn't load trips"
                       description="Pull to refresh or try again in a moment."
                       refresh={() => tripsQuery.refetch()}
                     />
                   ) : null}
-                  <Box gap="sm" paddingTop="xl">
+                  <Box gap="sm">
                     <Text variant="headingMd" color="gray900">
                       Welcome back, {profile.greetingName}
                     </Text>

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -19,12 +19,19 @@ export default function RootLayout() {
 
   const [fontsLoaded] = useFonts({
     "Figtree-Light": require("../assets/fonts/Figtree-Light.ttf"),
+    "Figtree-LightItalic": require("../assets/fonts/Figtree-LightItalic.ttf"),
     "Figtree-Regular": require("../assets/fonts/Figtree-Regular.ttf"),
+    "Figtree-Italic": require("../assets/fonts/Figtree-Italic.ttf"),
     "Figtree-Medium": require("../assets/fonts/Figtree-Medium.ttf"),
+    "Figtree-MediumItalic": require("../assets/fonts/Figtree-MediumItalic.ttf"),
     "Figtree-SemiBold": require("../assets/fonts/Figtree-SemiBold.ttf"),
+    "Figtree-SemiBoldItalic": require("../assets/fonts/Figtree-SemiBoldItalic.ttf"),
     "Figtree-Bold": require("../assets/fonts/Figtree-Bold.ttf"),
+    "Figtree-BoldItalic": require("../assets/fonts/Figtree-BoldItalic.ttf"),
     "Figtree-ExtraBold": require("../assets/fonts/Figtree-ExtraBold.ttf"),
+    "Figtree-ExtraBoldItalic": require("../assets/fonts/Figtree-ExtraBoldItalic.ttf"),
     "Figtree-Black": require("../assets/fonts/Figtree-Black.ttf"),
+    "Figtree-BlackItalic": require("../assets/fonts/Figtree-BlackItalic.ttf"),
     "Zain-ExtraBold": require("../assets/fonts/Zain-ExtraBold.ttf"),
   });
 


### PR DESCRIPTION
# Description

look the same but is actually different if you look close enough

## How has this been tested?
<img width="1290" height="2796" alt="Simulator Screenshot - bigger size - 2026-04-11 at 17 43 53" src="https://github.com/user-attachments/assets/21a45d84-6a6d-40f5-804a-1d503d068b66" />

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Tightened vertical spacing on the home screen empty-state card (gap reduced from sm to xxs)
- Adjusted globe emoji icon sizing and baseline alignment in the empty-state card
- Removed loading skeleton UI when displaying trips error state
- Updated text styling to use explicit font family for italic text instead of style property

## Changes by Category

**Fixes**
- home-upcoming-empty-card.tsx: Corrected spacing and alignment of the empty-state card icon and text
- home-screen.tsx: Removed trips-loading skeleton and unnecessary top padding

**Infra**
- _layout.tsx: Registered italic font variants for Figtree font weights (LightItalic, Italic, MediumItalic, SemiBoldItalic, BoldItalic, ExtraBoldItalic, BlackItalic)

## Author Contribution

| File | Added | Removed | Change |
|------|-------|---------|--------|
| frontend/app/(app)/components/home/home-upcoming-empty-card.tsx | 6 | 5 | +1 |
| frontend/app/(app)/home-screen.tsx | 2 | 9 | -7 |
| frontend/app/_layout.tsx | 7 | 0 | +7 |
| **Total** | **15** | **14** | **+1** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->