### PR TITLE
feat: Fix Toast

### DIFF
--- a/frontend/app/(app)/trips/[id]/polls/components/create-poll-sheet.tsx
+++ b/frontend/app/(app)/trips/[id]/polls/components/create-poll-sheet.tsx
@@ -140,6 +140,11 @@ const CreatePollSheet = forwardRef<
         });
       }
       close();
+      toast.show({
+        message: "Poll created!",
+        subtitle: "Your trip will get a notification to vote.",
+        action: { label: "Dismiss", onPress: () => {} },
+      });
       onCreated?.();
     } catch (e) {
       console.error("Failed to create poll:", e);

--- a/frontend/design-system/primitives/toast-manager.tsx
+++ b/frontend/design-system/primitives/toast-manager.tsx
@@ -12,7 +12,7 @@ import { Animated, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { CoreSize } from "../tokens/core-size";
 import { Layout } from "../tokens/layout";
-import Toast from "./toast";
+import Toast, { ToastVariant } from "./toast";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -24,6 +24,7 @@ type ToastAction = {
 type ToastConfig = {
   message: string;
   subtitle?: string;
+  variant?: ToastVariant;
   action?: ToastAction;
   showClose?: boolean;
   duration?: number;
@@ -176,6 +177,7 @@ const ToastItem = ({
       <Toast
         message={entry.message}
         subtitle={entry.subtitle}
+        variant={entry.variant}
         action={entry.action}
         showClose={showClose}
         onClose={hide}

--- a/frontend/design-system/primitives/toast-manager.tsx
+++ b/frontend/design-system/primitives/toast-manager.tsx
@@ -24,7 +24,6 @@ type ToastAction = {
 type ToastConfig = {
   message: string;
   subtitle?: string;
-  variant?: "pollSent" | "default";
   action?: ToastAction;
   showClose?: boolean;
   duration?: number;
@@ -177,7 +176,6 @@ const ToastItem = ({
       <Toast
         message={entry.message}
         subtitle={entry.subtitle}
-        variant={entry.variant}
         action={entry.action}
         showClose={showClose}
         onClose={hide}

--- a/frontend/design-system/primitives/toast.tsx
+++ b/frontend/design-system/primitives/toast.tsx
@@ -9,9 +9,12 @@ import { Layout } from "../tokens/layout";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
+export type ToastVariant = "success" | "neutral";
+
 export type ToastProps = {
   message: string;
   subtitle?: string;
+  variant?: ToastVariant;
   action?: {
     label: string;
     onPress: () => void;
@@ -25,30 +28,33 @@ export type ToastProps = {
 export default function Toast({
   message,
   subtitle,
+  variant = "neutral",
   action,
   showClose = true,
   onClose,
 }: ToastProps) {
-  const hasSubtitle = subtitle !== undefined;
-  const iconColor = hasSubtitle ? ColorPalette.brand500 : ColorPalette.gray950;
+  const iconColor =
+    variant === "success" ? ColorPalette.brand500 : ColorPalette.gray950;
 
   return (
     <Box style={styles.container}>
       <Box style={styles.content}>
         <Check size={CoreSize.iconSm} color={iconColor} strokeWidth={2.5} />
 
-        {hasSubtitle ? (
+        {variant === "success" ? (
           <Box style={styles.textStack}>
             <Text variant="headingSm" color="gray950" numberOfLines={1}>
               {message}
             </Text>
-            <Text
-              variant="bodySmDefault"
-              style={styles.subtitle}
-              numberOfLines={2}
-            >
-              {subtitle}
-            </Text>
+            {subtitle ? (
+              <Text
+                variant="bodySmDefault"
+                style={styles.subtitle}
+                numberOfLines={2}
+              >
+                {subtitle}
+              </Text>
+            ) : null}
           </Box>
         ) : (
           <Text
@@ -78,7 +84,12 @@ export default function Toast({
           </Text>
         </Pressable>
       ) : showClose ? (
-        <Pressable onPress={onClose} hitSlop={8}>
+        <Pressable
+          onPress={onClose}
+          hitSlop={8}
+          accessibilityLabel="Dismiss"
+          accessibilityRole="button"
+        >
           <X size={CoreSize.iconSm} color={ColorPalette.gray950} />
         </Pressable>
       ) : null}
@@ -94,7 +105,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     backgroundColor: ColorPalette.white,
     borderRadius: CornerRadius.xl,
-    paddingVertical: Layout.spacing.sm + 4,
+    paddingVertical: Layout.spacing.sm + Layout.spacing.xxs,
     paddingHorizontal: Layout.spacing.sm,
     gap: Layout.spacing.sm,
     shadowColor: ColorPalette.black,

--- a/frontend/design-system/primitives/toast.tsx
+++ b/frontend/design-system/primitives/toast.tsx
@@ -12,7 +12,6 @@ import { Layout } from "../tokens/layout";
 export type ToastProps = {
   message: string;
   subtitle?: string;
-  variant?: "pollSent" | "default";
   action?: {
     label: string;
     onPress: () => void;
@@ -21,65 +20,49 @@ export type ToastProps = {
   onClose: () => void;
 };
 
-// ─── Poll-sent style (Figma 3859-27171) ──────────────────────────────────────
+// ─── Component ───────────────────────────────────────────────────────────────
 
-function PollSentToast({
+export default function Toast({
   message,
   subtitle,
-  onClose,
-}: Pick<ToastProps, "message" | "subtitle" | "onClose">) {
-  return (
-    <Pressable onPress={onClose}>
-      <Box style={styles.pollSentContainer}>
-        {/* Orange circle check icon */}
-        <Box style={styles.pollSentIcon}>
-          <Check size={22} color={ColorPalette.white} strokeWidth={2.5} />
-        </Box>
-
-        {/* Text */}
-        <Box style={styles.pollSentText}>
-          <Text variant="headingSm" color="gray950" numberOfLines={1}>
-            {message}
-          </Text>
-          {subtitle ? (
-            <Text
-              variant="bodySmDefault"
-              style={styles.pollSentSubtitle}
-              numberOfLines={2}
-            >
-              {subtitle}
-            </Text>
-          ) : null}
-        </Box>
-      </Box>
-    </Pressable>
-  );
-}
-
-// ─── Default style ────────────────────────────────────────────────────────────
-
-function DefaultToast({
-  message,
   action,
   showClose = true,
   onClose,
 }: ToastProps) {
+  const hasSubtitle = subtitle !== undefined;
+  const iconColor = hasSubtitle ? ColorPalette.brand500 : ColorPalette.gray950;
+
   return (
-    <Box style={styles.toast}>
-      <Box style={styles.checkCircle}>
-        <Check size={16} color={ColorPalette.gray900} strokeWidth={2.5} />
+    <Box style={styles.container}>
+      <Box style={styles.content}>
+        <Check size={CoreSize.iconSm} color={iconColor} strokeWidth={2.5} />
+
+        {hasSubtitle ? (
+          <Box style={styles.textStack}>
+            <Text variant="headingSm" color="gray950" numberOfLines={1}>
+              {message}
+            </Text>
+            <Text
+              variant="bodySmDefault"
+              style={styles.subtitle}
+              numberOfLines={2}
+            >
+              {subtitle}
+            </Text>
+          </Box>
+        ) : (
+          <Text
+            variant="bodyMedium"
+            color="gray950"
+            style={styles.message}
+            numberOfLines={2}
+          >
+            {message}
+          </Text>
+        )}
       </Box>
 
-      <Text
-        variant="bodySmMedium"
-        color="gray900"
-        style={styles.message}
-        numberOfLines={2}
-      >
-        {message}
-      </Text>
-
-      {action && (
+      {action ? (
         <Pressable
           onPress={() => {
             try {
@@ -90,91 +73,52 @@ function DefaultToast({
           }}
           hitSlop={8}
         >
-          <Text variant="bodySmMedium" style={styles.actionLabel}>
+          <Text variant="bodyStrong" style={styles.actionLabel}>
             {action.label}
           </Text>
         </Pressable>
-      )}
-
-      {showClose && !action && (
-        <Pressable onPress={onClose} hitSlop={8} style={styles.closeButton}>
-          <X size={18} color={ColorPalette.gray500} />
+      ) : showClose ? (
+        <Pressable onPress={onClose} hitSlop={8}>
+          <X size={CoreSize.iconSm} color={ColorPalette.gray950} />
         </Pressable>
-      )}
+      ) : null}
     </Box>
   );
 }
 
-// ─── Component ───────────────────────────────────────────────────────────────
-
-export default function Toast(props: ToastProps) {
-  if (props.variant === "pollSent" || props.subtitle !== undefined) {
-    return <PollSentToast {...props} />;
-  }
-  return <DefaultToast {...props} />;
-}
-
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
-const ICON_SIZE = 48;
-
 const styles = StyleSheet.create({
-  // Default toast
-  toast: {
+  container: {
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: ColorPalette.white,
-    borderRadius: CornerRadius.md,
-    paddingVertical: 14,
+    borderRadius: CornerRadius.xl,
+    paddingVertical: Layout.spacing.sm + 4,
     paddingHorizontal: Layout.spacing.sm,
-    gap: 12,
-    shadowColor: ColorPalette.gray900,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 12,
-    elevation: 6,
+    gap: Layout.spacing.sm,
+    shadowColor: ColorPalette.black,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.25,
+    shadowRadius: 20,
+    elevation: 8,
   },
-  checkCircle: {
-    width: CoreSize.sm,
-    height: CoreSize.sm,
+  content: {
+    flex: 1,
+    flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
+    gap: Layout.spacing.xs,
   },
   message: {
     flex: 1,
   },
-  actionLabel: {
-    color: ColorPalette.statusInfo,
-    fontWeight: "600",
-  },
-  closeButton: {
-    padding: 2,
-  },
-
-  // Poll-sent toast (matches Figma 3859-27171)
-  pollSentContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: ColorPalette.white,
-    borderRadius: CornerRadius.md,
-    borderWidth: 1,
-    borderColor: ColorPalette.gray200,
-    padding: Layout.spacing.xs,
-    gap: Layout.spacing.sm,
-  },
-  pollSentIcon: {
-    width: ICON_SIZE,
-    height: ICON_SIZE,
-    borderRadius: ICON_SIZE / 2,
-    backgroundColor: ColorPalette.brand500,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  pollSentText: {
+  textStack: {
     flex: 1,
-    gap: Layout.spacing.xxs,
   },
-  pollSentSubtitle: {
+  subtitle: {
     color: ColorPalette.gray500,
+  },
+  actionLabel: {
+    color: ColorPalette.blue500,
   },
 });


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->
- added the correct toast from hifis

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

<img width="377" height="788" alt="simulator_screenshot_ED9C56D1-87B3-42D7-AD0E-B0C489F0C052" src="https://github.com/user-attachments/assets/e3e9ef7a-c141-4f94-9156-0fe2c2ee1634" />

<img width="377" height="788" alt="simulator_screenshot_ED043390-B592-42FB-A43B-9F40CD2514B6" src="https://github.com/user-attachments/assets/eb1728f9-99f0-458a-9843-425691312d99" />

## Checklist

* [x]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [x] New and existing tests pass locally with my changes.
* [x] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Poll creation now shows a success toast: "Poll created!" with subtitle "Your trip will get a notification to vote" and a Dismiss action.
- Toast component consolidated: two variants replaced by ToastVariant = "success" | "neutral"; success toasts show message + subtitle with checkmark, neutral toasts show message-only.
- Action button rendering now takes precedence; close control renders only when no action is present. Icon sizes, colors, typography, and accessibility labels standardized.

**Features**
- Added poll creation success toast notification in create-poll-sheet component.

**Improvements**
- Refactored Toast into a single unified component (ToastVariant: "success" | "neutral") replacing PollSentToast/DefaultToast.
- Typed ToastConfig.variant to use the exported ToastVariant type (toast-manager → toast) and updated manager to pass the new variant type.
- Consolidated toast styling, adjusted geometry, shadow, padding, typography, icon sizes/colors, and added accessibilityLabel on the close control.

**Author contribution**

| File | Added | Removed |
|------|------:|-------:|
| frontend/app/(app)/trips/[id]/polls/components/create-poll-sheet.tsx | 5 | 0 |
| frontend/design-system/primitives/toast-manager.tsx | 2 | 2 |
| frontend/design-system/primitives/toast.tsx | 67 | 112 |
| **Total** | **74** | **114** |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->