### PR TITLE
hot fix: create profile on home if user defined

### DIFF
--- a/frontend/app/(app)/components/create-profile-sheet.tsx
+++ b/frontend/app/(app)/components/create-profile-sheet.tsx
@@ -18,11 +18,12 @@ export function CreateProfileSheet({
   return (
     <BottomSheet
       ref={bottomSheetRef}
-      snapPoints={["80%", "95%"]}
+      snapPoints={["50%", "60%"]}
+      initialIndex={needsProfile ? 0 : -1}
       disableClose={needsProfile}
     >
-      <Box flex={1} padding="lg" gap="lg">
-        <Text variant="bodyMedium" color="white">
+      <Box flex={1} padding="sm" gap="lg">
+        <Text variant="bodyMedium" color="black">
           Create a profile
         </Text>
         <Box justifyContent="center" alignItems="center">

--- a/frontend/app/(app)/home-screen.tsx
+++ b/frontend/app/(app)/home-screen.tsx
@@ -3,6 +3,7 @@ import { joinTripByInvite } from "@/api/memberships/useJoinTripByInvite";
 import { useGetAllTrips } from "@/api/trips/useGetAllTrips";
 import { getTrip } from "@/api/trips/useGetTrip";
 import { useUpdateTrip } from "@/api/trips/useUpdateTrip";
+import { CreateProfileSheet } from "@/app/(app)/components/create-profile-sheet";
 import type { CreateTripParams } from "@/app/(app)/components/create-trip-sheet";
 import { CreateTripSheet } from "@/app/(app)/components/create-trip-sheet";
 import {
@@ -19,17 +20,14 @@ import {
 } from "@/app/(app)/components/home/trip-date-utils";
 import { UpcomingTripHeroCard } from "@/app/(app)/components/home/upcoming-trip-hero-card";
 import { useHomeUIStore } from "@/app/(app)/store/home-ui-store";
-import CompleteProfileForm from "@/app/(auth)/components/complete-profile-form";
 import { useUserStore } from "@/auth/store";
 import { useUser } from "@/contexts/user";
 import {
   AnimatedBox,
-  BottomSheet,
   Box,
   Button,
   ErrorState,
   Icon,
-  ImagePicker,
   ProfileAvatarButton,
   SkeletonRect,
   Text,
@@ -114,7 +112,6 @@ export default function HomeScreen() {
     (s) => s.clearCreateTripSheetRequest,
   );
 
-  const [profilePhoto, setProfilePhoto] = useState<string | null>(null);
   const [showToast, setShowToast] = useState(false);
   const [toastPrefix, setToastPrefix] = useState("");
   const [toastBold, setToastBold] = useState<string | null>(null);
@@ -163,15 +160,6 @@ export default function HomeScreen() {
     viewportWidth - Layout.spacing.sm * 2,
   );
   const upcomingCardGap = 12;
-
-  useEffect(() => {
-    if (needsProfile) {
-      const t = setTimeout(() => {
-        bottomSheetRef.current?.snapToIndex(0);
-      }, 300);
-      return () => clearTimeout(t);
-    }
-  }, [needsProfile]);
 
   useEffect(() => {
     if (createTripSheetRequested) {
@@ -519,30 +507,11 @@ export default function HomeScreen() {
         </Box>
       </ScrollView>
 
-      <BottomSheet
-        ref={bottomSheetRef}
-        snapPoints={["80%", "95%"]}
-        disableClose={needsProfile}
-      >
-        <Box flex={1} padding="lg" gap="lg">
-          <Text variant="bodyMedium" color="gray900">
-            Create a profile
-          </Text>
-          <Box justifyContent="center" alignItems="center">
-            <ImagePicker
-              variant="circular"
-              size={88}
-              value={profilePhoto ?? undefined}
-              onChange={(uri) => setProfilePhoto(uri)}
-              placeholder="Add photo"
-            />
-          </Box>
-          <CompleteProfileForm
-            profilePhotoUri={profilePhoto}
-            onSuccess={handleProfileCreated}
-          />
-        </Box>
-      </BottomSheet>
+      <CreateProfileSheet
+        bottomSheetRef={bottomSheetRef}
+        needsProfile={needsProfile}
+        onSuccess={handleProfileCreated}
+      />
 
       <CreateTripSheet
         bottomSheetRef={createTripSheetRef}

--- a/frontend/app/(app)/trips/[id]/pitches/components/set-destination-confirm-modal.tsx
+++ b/frontend/app/(app)/trips/[id]/pitches/components/set-destination-confirm-modal.tsx
@@ -34,7 +34,6 @@ export function SetDestinationConfirmModal({
       ref={sheetRef}
       snapPoints={["28%"]}
       initialIndex={-1}
-      hideHandle={true}
       onClose={onCancel}
     >
       <Box


### PR DESCRIPTION
shoutout to Jojo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Profile creation sheet now opens at smaller heights (50-60% of screen) instead of full-height, creating a more focused interface
- Profile sheet is now prevented from being dismissed when profile creation is required (`disableClose` behavior)
- Profile creation form text styling updated for better contrast with black text on light background
- Bottom sheet handle now displays by default in destination confirmation modal instead of being force-hidden

## Changes by Category

### Improvements
- Extracted profile creation logic into dedicated `CreateProfileSheet` component for improved code organization and reusability
- Simplified `HomeScreen` by delegating profile sheet management to child component
- Reduced profile sheet size and padding for a more compact, focused user experience
- Updated destination confirmation modal to use controlled visibility pattern via visible prop and useEffect

## Author Contribution

| File | Added | Removed |
|------|-------|---------|
| create-profile-sheet.tsx | 45 | 0 |
| home-screen.tsx | 6 | 37 |
| set-destination-confirm-modal.tsx | 1 | 19 |
| **Total** | **+52** | **-56** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->