### PR TITLE
added avatars and member counts for trip details and activities

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -6034,6 +6034,15 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "comment_count": {
+                    "type": "integer"
+                },
+                "comment_previews": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CommenterPreview"
+                    }
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -8208,6 +8217,15 @@ const docTemplate = `{
                 },
                 "location": {
                     "type": "string"
+                },
+                "member_count": {
+                    "type": "integer"
+                },
+                "member_previews": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CommenterPreview"
+                    }
                 },
                 "name": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6028,6 +6028,15 @@
                         "type": "string"
                     }
                 },
+                "comment_count": {
+                    "type": "integer"
+                },
+                "comment_previews": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CommenterPreview"
+                    }
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -8202,6 +8211,15 @@
                 },
                 "location": {
                     "type": "string"
+                },
+                "member_count": {
+                    "type": "integer"
+                },
+                "member_previews": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.CommenterPreview"
+                    }
                 },
                 "name": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -47,6 +47,12 @@ definitions:
         items:
           type: string
         type: array
+      comment_count:
+        type: integer
+      comment_previews:
+        items:
+          $ref: '#/definitions/models.CommenterPreview'
+        type: array
       created_at:
         type: string
       dates:
@@ -1508,6 +1514,12 @@ definitions:
         type: string
       location:
         type: string
+      member_count:
+        type: integer
+      member_previews:
+        items:
+          $ref: '#/definitions/models.CommenterPreview'
+        type: array
       name:
         type: string
       pitch_deadline:

--- a/backend/internal/models/activity.go
+++ b/backend/internal/models/activity.go
@@ -172,6 +172,8 @@ type ActivityAPIResponse struct {
 	Images             []ActivityImageResponse     `json:"image_ids"`
 	GoingCount         int                         `json:"going_count"`
 	GoingUsers         []ActivityGoingUserResponse `json:"going_users"`
+	CommentCount       int                         `json:"comment_count"`
+	CommentPreviews    []CommenterPreview          `json:"comment_previews"`
 }
 
 // AddCategoryResponse represents the response for adding a category to an activity

--- a/backend/internal/models/trips.go
+++ b/backend/internal/models/trips.go
@@ -63,6 +63,22 @@ type TripCursorPageResult struct {
 	Limit      int                `json:"limit"`
 }
 
+// TripMemberPreviewDB is an internal struct used for building member previews in list responses.
+// It contains the profile picture file key (not URL) to enable batch URL resolution.
+type TripMemberPreviewDB struct {
+	UserID            uuid.UUID `bun:"user_id"`
+	Name              string    `bun:"member_name"`
+	Username          string    `bun:"member_username"`
+	ProfilePictureKey *string   `bun:"member_pfp_key"`
+}
+
+// TripMemberStats contains the total member count and up to a small preview set
+// of members (for avatar stacks).
+type TripMemberStats struct {
+	Count    int
+	Previews []TripMemberPreviewDB
+}
+
 type TripDatabaseResponse struct {
 	TripID        uuid.UUID  `bun:"trip_id"`
 	Name          string     `bun:"name"`
@@ -92,6 +108,8 @@ type TripAPIResponse struct {
 	StartDate     *time.Time `json:"start_date,omitempty" swaggertype:"string" format:"date-time"`
 	EndDate       *time.Time `json:"end_date,omitempty" swaggertype:"string" format:"date-time"`
 	Location      *string    `json:"location,omitempty"`
+	MemberCount   int        `json:"member_count"`
+	MemberPreviews []CommenterPreview `json:"member_previews"`
 	CreatedAt     time.Time  `json:"created_at"`
 	UpdatedAt     time.Time  `json:"updated_at"`
 }

--- a/backend/internal/repository/comments.go
+++ b/backend/internal/repository/comments.go
@@ -19,6 +19,7 @@ type CommentRepository interface {
 	Delete(ctx context.Context, id uuid.UUID, userID uuid.UUID) error
 	FindPaginatedComments(ctx context.Context, tripID uuid.UUID, entityType models.EntityType, entityID uuid.UUID, limit int, cursor *models.CommentCursor) ([]*models.CommentDatabaseResponse, error)
 	GetCommentStatsForPitches(ctx context.Context, pitchIDs []uuid.UUID) (map[uuid.UUID]*models.PitchCommentStats, error)
+	GetCommentStatsForActivities(ctx context.Context, activityIDs []uuid.UUID) (map[uuid.UUID]*models.PitchCommentStats, error)
 }
 
 var _ CommentRepository = (*commentRepository)(nil)
@@ -157,6 +158,71 @@ func (r *commentRepository) GetCommentStatsForPitches(ctx context.Context, pitch
 		if !ok {
 			stats = &models.PitchCommentStats{Count: row.TotalCommentCount}
 			result[row.PitchID] = stats
+		}
+		stats.Previews = append(stats.Previews, models.PitchCommenterDB{
+			UserID:            row.UserID,
+			Name:              row.CommenterName,
+			Username:          row.CommenterUsername,
+			ProfilePictureKey: row.CommenterPfpKey,
+		})
+	}
+	return result, nil
+}
+
+func (r *commentRepository) GetCommentStatsForActivities(ctx context.Context, activityIDs []uuid.UUID) (map[uuid.UUID]*models.PitchCommentStats, error) {
+	result := make(map[uuid.UUID]*models.PitchCommentStats, len(activityIDs))
+	if len(activityIDs) == 0 {
+		return result, nil
+	}
+
+	type statsRow struct {
+		ActivityID        uuid.UUID `bun:"activity_id"`
+		UserID            uuid.UUID `bun:"user_id"`
+		CommenterName     string    `bun:"commenter_name"`
+		CommenterUsername string    `bun:"commenter_username"`
+		CommenterPfpKey   *string   `bun:"commenter_pfp_key"`
+		TotalCommentCount int       `bun:"total_comment_count"`
+	}
+
+	var rows []statsRow
+	err := r.db.NewSelect().
+		TableExpr(`(
+			SELECT
+				c.entity_id                                                                               AS activity_id,
+				c.user_id,
+				u.name                                                                                    AS commenter_name,
+				u.username                                                                                AS commenter_username,
+				pfp.file_key                                                                              AS commenter_pfp_key,
+				SUM(COUNT(c.id)) OVER (PARTITION BY c.entity_id)                                         AS total_comment_count,
+				ROW_NUMBER() OVER (PARTITION BY c.entity_id ORDER BY MIN(c.created_at))                  AS rn
+			FROM comments AS c
+			JOIN users AS u ON u.id = c.user_id
+			LEFT JOIN images AS pfp
+				ON u.profile_picture IS NOT NULL
+				AND pfp.image_id = u.profile_picture
+				AND pfp.size = ?
+				AND pfp.status = ?
+			WHERE c.entity_type = ?
+			  AND c.entity_id IN (?)
+			GROUP BY c.entity_id, c.user_id, u.name, u.username, pfp.file_key
+		) AS ranked`,
+			models.ImageSizeSmall,
+			models.UploadStatusConfirmed,
+			models.ActivityEntity,
+			bun.In(activityIDs),
+		).
+		ColumnExpr("activity_id, user_id, commenter_name, commenter_username, commenter_pfp_key, total_comment_count").
+		Where("rn <= ?", maxCommentPreviewCount).
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		stats, ok := result[row.ActivityID]
+		if !ok {
+			stats = &models.PitchCommentStats{Count: row.TotalCommentCount}
+			result[row.ActivityID] = stats
 		}
 		stats.Previews = append(stats.Previews, models.PitchCommenterDB{
 			UserID:            row.UserID,

--- a/backend/internal/repository/membership.go
+++ b/backend/internal/repository/membership.go
@@ -23,6 +23,7 @@ type MembershipRepository interface {
 	IsAdmin(ctx context.Context, tripID, userID uuid.UUID) (bool, error)
 	CountMembers(ctx context.Context, tripID uuid.UUID) (int, error)
 	CountAdmins(ctx context.Context, tripID uuid.UUID) (int, error)
+	GetMemberStatsForTrips(ctx context.Context, tripIDs []uuid.UUID) (map[uuid.UUID]*models.TripMemberStats, error)
 	Update(ctx context.Context, userID, tripID uuid.UUID, req *models.UpdateMembershipRequest) (*models.Membership, error)
 	UpdateNotificationPreferences(ctx context.Context, userID, tripID uuid.UUID, req *models.UpdateNotificationPreferencesRequest) (*models.Membership, error)
 	Delete(ctx context.Context, userID, tripID uuid.UUID) error
@@ -132,6 +133,78 @@ func (r *membershipRepository) FindByTripIDWithCursor(ctx context.Context, tripI
 	}
 
 	return memberships, nextCursor, nil
+}
+
+func (r *membershipRepository) GetMemberStatsForTrips(ctx context.Context, tripIDs []uuid.UUID) (map[uuid.UUID]*models.TripMemberStats, error) {
+	result := make(map[uuid.UUID]*models.TripMemberStats, len(tripIDs))
+	if len(tripIDs) == 0 {
+		return result, nil
+	}
+
+	type statsRow struct {
+		TripID           uuid.UUID `bun:"trip_id"`
+		UserID           uuid.UUID `bun:"user_id"`
+		MemberName       string    `bun:"member_name"`
+		MemberUsername   string    `bun:"member_username"`
+		MemberPfpKey     *string   `bun:"member_pfp_key"`
+		TotalMemberCount int       `bun:"total_member_count"`
+	}
+
+	var rows []statsRow
+	err := r.db.NewSelect().
+		TableExpr(`(
+			SELECT
+				m.trip_id,
+				m.user_id,
+				u.name                                                                                     AS member_name,
+				u.username                                                                                 AS member_username,
+				pfp.file_key                                                                               AS member_pfp_key,
+				COUNT(*) OVER (PARTITION BY m.trip_id)                                                    AS total_member_count,
+				ROW_NUMBER() OVER (PARTITION BY m.trip_id ORDER BY m.created_at, m.user_id)               AS rn
+			FROM memberships AS m
+			JOIN users AS u ON u.id = m.user_id
+			LEFT JOIN images AS pfp
+				ON u.profile_picture IS NOT NULL
+				AND pfp.image_id = u.profile_picture
+				AND pfp.size = ?
+				AND pfp.status = ?
+			WHERE m.trip_id IN (?)
+		) AS ranked`,
+			models.ImageSizeSmall,
+			models.UploadStatusConfirmed,
+			bun.In(tripIDs),
+		).
+		ColumnExpr("trip_id, user_id, member_name, member_username, member_pfp_key, total_member_count").
+		Where("rn <= ?", 3).
+		Scan(ctx, &rows)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		stats, ok := result[row.TripID]
+		if !ok {
+			stats = &models.TripMemberStats{Count: row.TotalMemberCount}
+			result[row.TripID] = stats
+		}
+		stats.Previews = append(stats.Previews, models.TripMemberPreviewDB{
+			UserID:            row.UserID,
+			Name:              row.MemberName,
+			Username:          row.MemberUsername,
+			ProfilePictureKey: row.MemberPfpKey,
+		})
+	}
+
+	for _, tripID := range tripIDs {
+		if _, ok := result[tripID]; !ok {
+			result[tripID] = &models.TripMemberStats{
+				Count:    0,
+				Previews: []models.TripMemberPreviewDB{},
+			}
+		}
+	}
+
+	return result, nil
 }
 
 // FindByUserID retrieves all trips a user is a member of

--- a/backend/internal/services/activity.go
+++ b/backend/internal/services/activity.go
@@ -327,11 +327,28 @@ func (s *ActivityService) buildActivityListResponse(ctx context.Context, activit
 		}
 	}
 
+	commentStatsMap, err := s.Comment.GetCommentStatsForActivities(ctx, activityIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	commentPreviewRows := make([]models.PitchCommenterDB, 0, len(activities)*3)
+	for _, id := range activityIDs {
+		stats := commentStatsMap[id]
+		if stats == nil {
+			continue
+		}
+		commentPreviewRows = append(commentPreviewRows, stats.Previews...)
+	}
+	commentPicURLMap := pagination.FetchFileURLs(ctx, s.fileService, commentPreviewRows, func(item models.PitchCommenterDB) *string {
+		return item.ProfilePictureKey
+	}, models.ImageSizeSmall)
+
 	fileURLMap := pagination.FetchFileURLs(ctx, s.fileService, activities, func(item *models.ActivityDatabaseResponse) *string {
 		return item.ProposerPictureKey
 	}, models.ImageSizeSmall)
 
-	apiActivities, err := s.convertToAPIActivities(ctx, activities, fileURLMap)
+	apiActivities, err := s.convertToAPIActivities(ctx, activities, fileURLMap, commentStatsMap, commentPicURLMap)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +356,12 @@ func (s *ActivityService) buildActivityListResponse(ctx context.Context, activit
 	return s.buildActivityPageResult(apiActivities, nextCursor, limit)
 }
 
-func mapToAPIResponse(activity *models.ActivityDatabaseResponse, proposerPictureURL *string) *models.ActivityAPIResponse {
+func mapToAPIResponse(
+	activity *models.ActivityDatabaseResponse,
+	proposerPictureURL *string,
+	commentCount int,
+	commentPreviews []models.CommenterPreview,
+) *models.ActivityAPIResponse {
 	return &models.ActivityAPIResponse{
 		ID:                 activity.ID,
 		TripID:             activity.TripID,
@@ -360,6 +382,8 @@ func mapToAPIResponse(activity *models.ActivityDatabaseResponse, proposerPicture
 		ProposerUsername:   activity.ProposerUsername,
 		ProposerPictureURL: proposerPictureURL,
 		CategoryNames:      activity.CategoryNames,
+		CommentCount:       commentCount,
+		CommentPreviews:    commentPreviews,
 	}
 }
 
@@ -381,14 +405,20 @@ func (s *ActivityService) toAPIResponse(ctx context.Context, activity *models.Ac
 		return u.ProfilePictureKey
 	}, models.ImageSizeSmall)
 
-	apiResp := mapToAPIResponse(activity, proposerPictureURL)
+	apiResp := mapToAPIResponse(activity, proposerPictureURL, 0, []models.CommenterPreview{})
 	apiResp.Images = buildImageResponses(activity.ImageKeys, imageURLMap)
 	apiResp.GoingUsers = resolveGoingUsers(activity.GoingUsers, picURLMap)
 	apiResp.GoingCount = len(apiResp.GoingUsers)
 	return apiResp, nil
 }
 
-func (s *ActivityService) convertToAPIActivities(ctx context.Context, activities []*models.ActivityDatabaseResponse, fileURLMap map[string]string) ([]*models.ActivityAPIResponse, error) {
+func (s *ActivityService) convertToAPIActivities(
+	ctx context.Context,
+	activities []*models.ActivityDatabaseResponse,
+	fileURLMap map[string]string,
+	commentStatsMap map[uuid.UUID]*models.PitchCommentStats,
+	commentPicURLMap map[string]string,
+) ([]*models.ActivityAPIResponse, error) {
 	imageURLMap, err := s.batchFetchImageURLs(ctx, activities)
 	if err != nil {
 		return nil, err
@@ -404,7 +434,30 @@ func (s *ActivityService) convertToAPIActivities(ctx context.Context, activities
 				proposerPictureURL = &url
 			}
 		}
-		apiResp := mapToAPIResponse(activity, proposerPictureURL)
+
+		commentCount := 0
+		commentPreviews := []models.CommenterPreview{}
+		if stats := commentStatsMap[activity.ID]; stats != nil {
+			commentCount = stats.Count
+			if len(stats.Previews) > 0 {
+				commentPreviews = make([]models.CommenterPreview, 0, len(stats.Previews))
+				for _, c := range stats.Previews {
+					preview := models.CommenterPreview{
+						UserID:   c.UserID,
+						Name:     c.Name,
+						Username: c.Username,
+					}
+					if c.ProfilePictureKey != nil {
+						if url, ok := commentPicURLMap[*c.ProfilePictureKey]; ok {
+							preview.ProfilePictureURL = &url
+						}
+					}
+					commentPreviews = append(commentPreviews, preview)
+				}
+			}
+		}
+
+		apiResp := mapToAPIResponse(activity, proposerPictureURL, commentCount, commentPreviews)
 		apiResp.Images = buildImageResponses(activity.ImageKeys, imageURLMap)
 		apiResp.GoingUsers = resolveGoingUsers(activity.GoingUsers, goingUserPicURLMap)
 		apiResp.GoingCount = len(apiResp.GoingUsers)

--- a/backend/internal/services/trips.go
+++ b/backend/internal/services/trips.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
+	"golang.org/x/sync/errgroup"
 )
 
 type TripServiceInterface interface {
@@ -172,21 +173,81 @@ func (s *TripService) GetTripsWithCursor(ctx context.Context, userID uuid.UUID, 
 		return nil, err
 	}
 
-	fileURLMap := pagination.FetchFileURLs(ctx, s.fileService, tripsData, func(item *models.TripDatabaseResponse) *string {
-		return item.CoverImageKey
-	}, models.ImageSizeMedium)
-	tripResponses := s.convertToAPITrips(tripsData, fileURLMap)
+	tripIDs := make([]uuid.UUID, 0, len(tripsData))
+	for _, t := range tripsData {
+		tripIDs = append(tripIDs, t.TripID)
+	}
+
+	var coverURLMap map[string]string
+	var memberStatsMap map[uuid.UUID]*models.TripMemberStats
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		coverURLMap = pagination.FetchFileURLs(gctx, s.fileService, tripsData, func(item *models.TripDatabaseResponse) *string {
+			return item.CoverImageKey
+		}, models.ImageSizeMedium)
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		memberStatsMap, err = s.Membership.GetMemberStatsForTrips(gctx, tripIDs)
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	memberPreviewRows := make([]models.TripMemberPreviewDB, 0, len(tripsData)*3)
+	for _, tripID := range tripIDs {
+		stats := memberStatsMap[tripID]
+		if stats == nil {
+			continue
+		}
+		memberPreviewRows = append(memberPreviewRows, stats.Previews...)
+	}
+	memberPicURLMap := pagination.FetchFileURLs(ctx, s.fileService, memberPreviewRows, func(item models.TripMemberPreviewDB) *string {
+		return item.ProfilePictureKey
+	}, models.ImageSizeSmall)
+
+	tripResponses := s.convertToAPITrips(tripsData, coverURLMap, memberStatsMap, memberPicURLMap)
 
 	return s.buildTripPageResult(tripResponses, nextCursor, limit)
 }
 
-func (s *TripService) convertToAPITrips(tripsData []*models.TripDatabaseResponse, fileURLMap map[string]string) []*models.TripAPIResponse {
+func (s *TripService) convertToAPITrips(
+	tripsData []*models.TripDatabaseResponse,
+	coverURLMap map[string]string,
+	memberStatsMap map[uuid.UUID]*models.TripMemberStats,
+	memberPicURLMap map[string]string,
+) []*models.TripAPIResponse {
 	tripResponses := make([]*models.TripAPIResponse, 0, len(tripsData))
 	for _, tripData := range tripsData {
 		var coverImageURL *string
 		if tripData.CoverImageKey != nil && *tripData.CoverImageKey != "" {
-			if url, exists := fileURLMap[*tripData.CoverImageKey]; exists {
+			if url, exists := coverURLMap[*tripData.CoverImageKey]; exists {
 				coverImageURL = &url
+			}
+		}
+
+		memberCount := 0
+		memberPreviews := []models.CommenterPreview{}
+		if stats := memberStatsMap[tripData.TripID]; stats != nil {
+			memberCount = stats.Count
+			if len(stats.Previews) > 0 {
+				memberPreviews = make([]models.CommenterPreview, 0, len(stats.Previews))
+				for _, m := range stats.Previews {
+					preview := models.CommenterPreview{
+						UserID:   m.UserID,
+						Name:     m.Name,
+						Username: m.Username,
+					}
+					if m.ProfilePictureKey != nil {
+						if url, ok := memberPicURLMap[*m.ProfilePictureKey]; ok {
+							preview.ProfilePictureURL = &url
+						}
+					}
+					memberPreviews = append(memberPreviews, preview)
+				}
 			}
 		}
 
@@ -202,6 +263,8 @@ func (s *TripService) convertToAPITrips(tripsData []*models.TripDatabaseResponse
 			StartDate:     tripData.StartDate,
 			EndDate:       tripData.EndDate,
 			Location:      tripData.Location,
+			MemberCount:   memberCount,
+			MemberPreviews: memberPreviews,
 			CreatedAt:     tripData.CreatedAt,
 			UpdatedAt:     tripData.UpdatedAt,
 		})

--- a/backend/internal/tests/activity_test.go
+++ b/backend/internal/tests/activity_test.go
@@ -983,6 +983,51 @@ func TestActivityLocationAndEstimatedPrice(t *testing.T) {
 		require.Equal(t, estimatedPrice, activity["estimated_price"])
 	})
 
+	t.Run("list activities includes comment_count and comment_previews", func(t *testing.T) {
+		app := fakes.GetSharedTestApp()
+
+		owner := createUser(t, app)
+		commenter := createUser(t, app)
+		trip := createTrip(t, app, owner)
+		addMember(t, app, owner, commenter, trip)
+
+		activityID := createActivity(t, app, owner, trip, "Activity With Comments")
+
+		testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  "/api/v1/comments",
+				Method: testkit.POST,
+				UserID: &commenter,
+				Body: models.CreateCommentRequest{
+					TripID:     uuid.MustParse(trip),
+					EntityType: models.ActivityEntity,
+					EntityID:   uuid.MustParse(activityID),
+					Content:    "Looks good!",
+				},
+			}).
+			AssertStatus(http.StatusCreated)
+
+		resp := testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  fmt.Sprintf("/api/v1/trips/%s/activities", trip),
+				Method: testkit.GET,
+				UserID: &owner,
+			}).
+			AssertStatus(http.StatusOK).
+			GetBody()
+
+		items := resp["items"].([]interface{})
+		require.Equal(t, 1, len(items))
+		activity := items[0].(map[string]interface{})
+
+		require.Equal(t, float64(1), activity["comment_count"])
+		previews, ok := activity["comment_previews"].([]interface{})
+		require.True(t, ok)
+		require.Equal(t, 1, len(previews))
+	})
+
 	t.Run("supports cents in estimated price", func(t *testing.T) {
 		app := fakes.GetSharedTestApp()
 

--- a/backend/internal/tests/notification_test.go
+++ b/backend/internal/tests/notification_test.go
@@ -171,6 +171,9 @@ func (n *noopMembershipRepo) CountMembers(ctx context.Context, tripID uuid.UUID)
 func (n *noopMembershipRepo) CountAdmins(ctx context.Context, tripID uuid.UUID) (int, error) {
 	return 0, nil
 }
+func (n *noopMembershipRepo) GetMemberStatsForTrips(ctx context.Context, tripIDs []uuid.UUID) (map[uuid.UUID]*models.TripMemberStats, error) {
+	return map[uuid.UUID]*models.TripMemberStats{}, nil
+}
 func (n *noopMembershipRepo) Update(ctx context.Context, userID, tripID uuid.UUID, req *models.UpdateMembershipRequest) (*models.Membership, error) {
 	return nil, nil
 }

--- a/backend/internal/tests/trips_test.go
+++ b/backend/internal/tests/trips_test.go
@@ -451,6 +451,37 @@ func TestTripCurrency(t *testing.T) {
 		require.Equal(t, "JPY", trip["currency"])
 	})
 
+	t.Run("list trips includes member_count and member_previews", func(t *testing.T) {
+		ownerID := createUser(t, app)
+		memberA := createUser(t, app)
+		memberB := createUser(t, app)
+		tripID := createTrip(t, app, ownerID)
+		addMember(t, app, ownerID, memberA, tripID)
+		addMember(t, app, ownerID, memberB, tripID)
+
+		listResp := testkit.New(t).
+			Request(testkit.Request{
+				App:    app,
+				Route:  "/api/v1/trips",
+				Method: testkit.GET,
+				UserID: &ownerID,
+			}).
+			AssertStatus(http.StatusOK).
+			GetBody()
+
+		items := listResp["items"].([]interface{})
+		require.Equal(t, 1, len(items))
+
+		trip := items[0].(map[string]interface{})
+		require.Equal(t, tripID, trip["id"])
+		require.Equal(t, float64(3), trip["member_count"])
+
+		previews, ok := trip["member_previews"].([]interface{})
+		require.True(t, ok)
+		require.GreaterOrEqual(t, len(previews), 1)
+		require.LessOrEqual(t, len(previews), 3)
+	})
+
 	t.Run("update trip currency", func(t *testing.T) {
 		ownerID := createUser(t, app)
 		tripID := createTrip(t, app, ownerID)

--- a/frontend/schemas/modelsActivityAPIResponse.json
+++ b/frontend/schemas/modelsActivityAPIResponse.json
@@ -2,6 +2,20 @@
   "type": "object",
   "properties": {
     "category_names": { "type": "array", "items": { "type": "string" } },
+    "comment_count": { "type": "integer" },
+    "comment_previews": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "profile_picture_url": { "type": "string" },
+          "user_id": { "type": "string" },
+          "username": { "type": "string" }
+        },
+        "x-readme-ref-name": "models.CommenterPreview"
+      }
+    },
     "created_at": { "type": "string" },
     "dates": {
       "type": "array",

--- a/frontend/schemas/modelsActivityCursorPageResult.json
+++ b/frontend/schemas/modelsActivityCursorPageResult.json
@@ -7,6 +7,20 @@
         "type": "object",
         "properties": {
           "category_names": { "type": "array", "items": { "type": "string" } },
+          "comment_count": { "type": "integer" },
+          "comment_previews": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "profile_picture_url": { "type": "string" },
+                "user_id": { "type": "string" },
+                "username": { "type": "string" }
+              },
+              "x-readme-ref-name": "models.CommenterPreview"
+            }
+          },
           "created_at": { "type": "string" },
           "dates": {
             "type": "array",

--- a/frontend/schemas/modelsSearchActivitiesResult.json
+++ b/frontend/schemas/modelsSearchActivitiesResult.json
@@ -7,6 +7,20 @@
         "type": "object",
         "properties": {
           "category_names": { "type": "array", "items": { "type": "string" } },
+          "comment_count": { "type": "integer" },
+          "comment_previews": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "profile_picture_url": { "type": "string" },
+                "user_id": { "type": "string" },
+                "username": { "type": "string" }
+              },
+              "x-readme-ref-name": "models.CommenterPreview"
+            }
+          },
           "created_at": { "type": "string" },
           "dates": {
             "type": "array",

--- a/frontend/schemas/modelsSearchTripsResult.json
+++ b/frontend/schemas/modelsSearchTripsResult.json
@@ -14,6 +14,20 @@
           "end_date": { "type": "string", "format": "date-time" },
           "id": { "type": "string" },
           "location": { "type": "string" },
+          "member_count": { "type": "integer" },
+          "member_previews": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "profile_picture_url": { "type": "string" },
+                "user_id": { "type": "string" },
+                "username": { "type": "string" }
+              },
+              "x-readme-ref-name": "models.CommenterPreview"
+            }
+          },
           "name": { "type": "string" },
           "pitch_deadline": { "type": "string" },
           "rank_poll_id": { "type": "string" },

--- a/frontend/schemas/modelsTripAPIResponse.json
+++ b/frontend/schemas/modelsTripAPIResponse.json
@@ -9,6 +9,20 @@
     "end_date": { "type": "string", "format": "date-time" },
     "id": { "type": "string" },
     "location": { "type": "string" },
+    "member_count": { "type": "integer" },
+    "member_previews": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "profile_picture_url": { "type": "string" },
+          "user_id": { "type": "string" },
+          "username": { "type": "string" }
+        },
+        "x-readme-ref-name": "models.CommenterPreview"
+      }
+    },
     "name": { "type": "string" },
     "pitch_deadline": { "type": "string" },
     "rank_poll_id": { "type": "string" },

--- a/frontend/schemas/modelsTripCursorPageResult.json
+++ b/frontend/schemas/modelsTripCursorPageResult.json
@@ -14,6 +14,20 @@
           "end_date": { "type": "string", "format": "date-time" },
           "id": { "type": "string" },
           "location": { "type": "string" },
+          "member_count": { "type": "integer" },
+          "member_previews": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "profile_picture_url": { "type": "string" },
+                "user_id": { "type": "string" },
+                "username": { "type": "string" }
+              },
+              "x-readme-ref-name": "models.CommenterPreview"
+            }
+          },
           "name": { "type": "string" },
           "pitch_deadline": { "type": "string" },
           "rank_poll_id": { "type": "string" },

--- a/frontend/types/schema.gen.ts
+++ b/frontend/types/schema.gen.ts
@@ -35,6 +35,7 @@ import type {
   ModelsDateRange,
   ModelsActivityTimeOfDay,
   ModelsActivity,
+  ModelsCommenterPreview,
   ModelsActivityGoingUserResponse,
   ModelsActivityImageResponse,
   ModelsActivityAPIResponse,
@@ -60,7 +61,6 @@ import type {
   ModelsCommentReactionUser,
   ModelsCommentReactionUsersResponse,
   ModelsCommentReactionsSummaryResponse,
-  ModelsCommenterPreview,
   ModelsImageSize,
   ModelsConfirmUploadRequest,
   ModelsConfirmUploadResponse,
@@ -876,6 +876,13 @@ export const modelsActivitySchema = z.object({
   updated_at: z.optional(z.string()),
 }) as unknown as z.ZodType<ModelsActivity>;
 
+export const modelsCommenterPreviewSchema = z.object({
+  name: z.optional(z.string()),
+  profile_picture_url: z.optional(z.string()),
+  user_id: z.optional(z.string()),
+  username: z.optional(z.string()),
+}) as unknown as z.ZodType<ModelsCommenterPreview>;
+
 export const modelsActivityGoingUserResponseSchema = z.object({
   name: z.optional(z.string()),
   profile_picture_url: z.optional(z.string()),
@@ -890,6 +897,10 @@ export const modelsActivityImageResponseSchema = z.object({
 
 export const modelsActivityAPIResponseSchema = z.object({
   category_names: z.optional(z.array(z.string())),
+  comment_count: z.optional(z.int()),
+  get comment_previews() {
+    return z.array(modelsCommenterPreviewSchema).optional();
+  },
   created_at: z.optional(z.string()),
   get dates() {
     return z.array(modelsDateRangeSchema).optional();
@@ -1090,13 +1101,6 @@ export const modelsCommentReactionsSummaryResponseSchema = z.object({
     return z.array(modelsCommentReactionSummarySchema).optional();
   },
 }) as unknown as z.ZodType<ModelsCommentReactionsSummaryResponse>;
-
-export const modelsCommenterPreviewSchema = z.object({
-  name: z.optional(z.string()),
-  profile_picture_url: z.optional(z.string()),
-  user_id: z.optional(z.string()),
-  username: z.optional(z.string()),
-}) as unknown as z.ZodType<ModelsCommenterPreview>;
 
 export const modelsImageSizeSchema = z.enum([
   "large",
@@ -1741,6 +1745,10 @@ export const modelsTripAPIResponseSchema = z.object({
   end_date: z.optional(z.iso.datetime()),
   id: z.optional(z.string()),
   location: z.optional(z.string()),
+  member_count: z.optional(z.int()),
+  get member_previews() {
+    return z.array(modelsCommenterPreviewSchema).optional();
+  },
   name: z.optional(z.string()),
   pitch_deadline: z.optional(z.string()),
   rank_poll_id: z.optional(z.string()),

--- a/frontend/types/types.gen.ts
+++ b/frontend/types/types.gen.ts
@@ -98,6 +98,25 @@ export type ModelsActivity = {
   updated_at?: string;
 };
 
+export type ModelsCommenterPreview = {
+  /**
+   * @type string | undefined
+   */
+  name?: string;
+  /**
+   * @type string | undefined
+   */
+  profile_picture_url?: string;
+  /**
+   * @type string | undefined
+   */
+  user_id?: string;
+  /**
+   * @type string | undefined
+   */
+  username?: string;
+};
+
 export type ModelsActivityGoingUserResponse = {
   /**
    * @type string | undefined
@@ -133,6 +152,14 @@ export type ModelsActivityAPIResponse = {
    * @type array | undefined
    */
   category_names?: string[];
+  /**
+   * @type integer | undefined
+   */
+  comment_count?: number;
+  /**
+   * @type array | undefined
+   */
+  comment_previews?: ModelsCommenterPreview[];
   /**
    * @type string | undefined
    */
@@ -602,25 +629,6 @@ export type ModelsCommentReactionsSummaryResponse = {
    * @type array | undefined
    */
   reactions?: ModelsCommentReactionSummary[];
-};
-
-export type ModelsCommenterPreview = {
-  /**
-   * @type string | undefined
-   */
-  name?: string;
-  /**
-   * @type string | undefined
-   */
-  profile_picture_url?: string;
-  /**
-   * @type string | undefined
-   */
-  user_id?: string;
-  /**
-   * @type string | undefined
-   */
-  username?: string;
 };
 
 export const modelsImageSize = {
@@ -2081,6 +2089,14 @@ export type ModelsTripAPIResponse = {
    * @type string | undefined
    */
   location?: string;
+  /**
+   * @type integer | undefined
+   */
+  member_count?: number;
+  /**
+   * @type array | undefined
+   */
+  member_previews?: ModelsCommenterPreview[];
   /**
    * @type string | undefined
    */


### PR DESCRIPTION
# Description

changed the backend api endpoints for get trips api and get activities api too get the member previews for a trip, and the comment previews on an activity

## How has this been tested?
added tests

## Checklist

* [x]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [x] New and existing tests pass locally with my changes.
* [x] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Trip list endpoint now returns member count and member preview data (up to 3 members with profile pictures) for each trip
- Activity list endpoint now returns comment count and comment preview data for each activity
- Profile picture URLs are resolved and included in member and commenter previews

## Changes by Category

### Features
- Added member count and member previews (including profile pictures) to trip API responses
- Added comment count and comment previews to activity API responses
- Implemented repository methods to fetch aggregated member and comment statistics with preview data

### Improvements
- Extended API response payloads with preview data to reduce client-side fetch requirements for trip and activity lists
- Optimized database queries using window functions (`ROW_NUMBER()`, `COUNT() OVER`) to efficiently retrieve limited preview sets

## Contribution Summary

| File | Added | Removed | Category |
|------|-------|---------|----------|
| backend/internal/models/activity.go | 2 | 0 | Models |
| backend/internal/models/trips.go | 18 | 0 | Models |
| backend/internal/repository/comments.go | 66 | 0 | Repository |
| backend/internal/repository/membership.go | 73 | 0 | Repository |
| backend/internal/services/activity.go | 58 | 5 | Services |
| backend/internal/services/trips.go | 69 | 6 | Services |
| backend/internal/tests/activity_test.go | 45 | 0 | Tests |
| backend/internal/tests/notification_test.go | 3 | 0 | Tests |
| backend/internal/tests/trips_test.go | 31 | 0 | Tests |
| **Total** | **365** | **11** | |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->