### PR TITLE
Fix category ordering

### DIFF
--- a/backend/internal/models/category.go
+++ b/backend/internal/models/category.go
@@ -11,11 +11,10 @@ var DefaultCategoryNames = []string{"housing", "transportation", "activities", "
 
 // DefaultCategoryLabels maps default category names to their display labels
 var DefaultCategoryLabels = map[string]string{
-	"housing":        "Housing",
-	"transportation": "Transportation",
-	"activities":     "Activities",
-	"polls":          "Polls",
 	"itinerary":      "Itinerary",
+	"polls":          "Polls",
+	"housing":        "Housing",
+	"activities":     "Activities",
 }
 
 // Category represents a category within a trip, identified by the combination of TripID and Name.

--- a/backend/internal/models/category.go
+++ b/backend/internal/models/category.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DefaultCategoryNames are the system categories created automatically when a new trip is created
-var DefaultCategoryNames = []string{"housing", "transportation", "activities", "polls", "itinerary"}
+var DefaultCategoryNames = []string{"itinerary", "polls", "housing", "activities"}
 
 // DefaultCategoryLabels maps default category names to their display labels
 var DefaultCategoryLabels = map[string]string{

--- a/backend/internal/tests/category_test.go
+++ b/backend/internal/tests/category_test.go
@@ -231,7 +231,6 @@ func TestCategoryGetByTripID(t *testing.T) {
 		}
 
 		require.Contains(t, categoryNames, "housing")
-		require.Contains(t, categoryNames, "transportation")
 		require.Contains(t, categoryNames, "activities")
 		require.Contains(t, categoryNames, "polls")
 		require.Contains(t, categoryNames, "itinerary")


### PR DESCRIPTION
# Description
- changed the ordering of default tabs and removed transportation tab

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-visible changes

- Removed transportation category from default trip categories
- Reordered default categories to match Figma design specifications
- Default categories now comprise: itinerary, polls, housing, and activities

## Fixes

- Corrected ordering of default category tabs to align with product design
- Removed transportation category from the default category set

## Changes by file

| File | Added | Removed |
|------|-------|---------|
| backend/internal/models/category.go | 2 | 3 |
| backend/internal/tests/category_test.go | 0 | 1 |
| **Total** | **2** | **4** |

## Detailed changes

- `DefaultCategoryLabels`: Removed `"transportation": "Transportation"` entry; reordered remaining categories (`itinerary`, `polls`, `housing`, `activities`)
- `TestCategoryGetByTripID`: Removed assertion validating transportation category presence in default categories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->