### PR TITLE
remove associated domain for build

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -16,7 +16,6 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.generateneutoggo.frontend",
-      "associatedDomains": ["applinks:dolphin-app-vemv9.ondigitalocean.app"],
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "UIBackgroundModes": ["remote-notification"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Removed iOS universal links association from app configuration, preventing deep link handling for the DigitalOcean domain on iOS
- The app no longer routes `applinks:dolphin-app-vemv9.ondigitalocean.app` traffic through iOS universal links

## Changes by Category

**Infra**
- Removed `associatedDomains` configuration from `expo.ios` in frontend Expo build config

## Author Contribution

| Metric | Count |
|--------|-------|
| Lines Added | 0 |
| Lines Removed | 1 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->