### PR TITLE
fix past trip

### DIFF
--- a/frontend/api/trips/custom/usePastTripsList.ts
+++ b/frontend/api/trips/custom/usePastTripsList.ts
@@ -50,7 +50,7 @@ export function usePastTripsList(endDateBefore: string) {
     return (
       data?.pages.flatMap((page) =>
         (page.items ?? []).filter((item) => {
-          if (!item.id || seen.has(item.id)) return false;
+          if (!item.id || !item.end_date || seen.has(item.id)) return false;
           seen.add(item.id);
           return true;
         }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Past trips list now properly excludes trips without an end_date, preventing incomplete trip data from appearing in the past trips view
- Ensures data integrity by validating both trip ID and end_date before displaying items
- Fixes potential display of invalid trip entries due to missing required date information

## Fixes

| File | Change | Impact |
|------|--------|--------|
| frontend/api/trips/custom/usePastTripsList.ts | Added validation to filter trips missing end_date | Prevents incomplete trips from being displayed in past trips list |

## Contribution Summary

| Metric | Count |
|--------|-------|
| Lines Added | 1 |
| Lines Removed | 1 |
| Files Modified | 1 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->