### PR TITLE
safeareaview to bottomsheet

### DIFF
--- a/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
+++ b/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
@@ -19,6 +19,7 @@ import React, {
 import { Dimensions, Keyboard, Platform } from "react-native";
 import { CornerRadius } from "../../tokens/corner-radius";
 import { Layout } from "../../tokens/layout";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export const InsideBottomSheetContext = createContext(false);
 
@@ -161,6 +162,7 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
             <BottomSheetView>
               <InsideBottomSheetContext.Provider value={true}>
                 {children}
+                <SafeAreaView edges={["bottom"]} />
               </InsideBottomSheetContext.Provider>
             </BottomSheetView>
           ) : (
@@ -174,6 +176,7 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
             >
               <InsideBottomSheetContext.Provider value={true}>
                 {children}
+                <SafeAreaView edges={["bottom"]} />
               </InsideBottomSheetContext.Provider>
             </BottomSheetScrollView>
           )}


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [ ]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [ ] New and existing tests pass locally with my changes.
* [ ] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Bottom sheet now respects device safe areas (notches, home indicators) by adding bottom padding automatically
- Safe area handling applied consistently across both scroll and non-scroll modes
- Prevents content from being obscured by system UI elements at the bottom of the screen

## Changes by Category

**Improvements**
- Added `SafeAreaView` wrapper with bottom edge handling to bottom-sheet content (both `BottomSheetView` and `BottomSheetScrollView` rendering paths)

## Author Contribution

| File | Added | Removed |
|------|-------|---------|
| `design-system/components/bottom-sheet/bottom-sheet.tsx` | 3 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->