### PR TITLE
bug bash

### DIFF
--- a/frontend/app/(app)/trips/[id]/components/create-fab.tsx
+++ b/frontend/app/(app)/trips/[id]/components/create-fab.tsx
@@ -93,7 +93,7 @@ export default function CreateFAB({
     {
       label: "Pitch",
       icon: Lightbulb,
-      onPress: () => router.push(`/trips/${tripID}/pitches/creation`),
+      onPress: () => router.push(`/trips/${tripID}/pitches`),
     },
     {
       label: "Poll",

--- a/frontend/app/(app)/trips/[id]/polls/components/rank-poll-card.tsx
+++ b/frontend/app/(app)/trips/[id]/polls/components/rank-poll-card.tsx
@@ -1,5 +1,6 @@
 import { useSubmitRanking } from "@/api/polls/useSubmitRanking";
-import { Box, Text, useToast } from "@/design-system";
+import { Box, Text, useToast, Button } from "@/design-system";
+import { router } from "expo-router";
 import { UserAvatar } from "@/design-system/components/avatars/user-avatar";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
@@ -27,6 +28,7 @@ type RankedOption = {
 type RankPollCardProps = {
   poll: ModelsRankPollResultsResponse;
   tripId: string;
+  tripPitchDeadline?: string;
   onRanked?: () => void;
   onPress?: () => void;
   previewMode?: boolean;
@@ -123,6 +125,7 @@ const DraggableRow = React.memo(function DraggableRow({
 export default function RankPollCard({
   poll,
   tripId,
+  tripPitchDeadline,
   onRanked,
   onPress,
   previewMode = false,
@@ -309,36 +312,69 @@ export default function RankPollCard({
           </Box>
         </Pressable>
 
-        {/* Rows */}
         <Box style={styles.list}>
-          {options.map((opt, i) => (
-            <DraggableRow
-              key={opt.id}
-              option={opt}
-              rank={i + 1}
-              isDragging={draggingId === opt.id}
-              translateY={translateY}
-              gesture={makeGesture(opt.id, i)}
-              closed={closed}
-            />
-          ))}
-        </Box>
-
-        {/* Submit */}
-        <Box alignItems="flex-end">
-          <TouchableOpacity
-            onPress={handleSubmit}
-            disabled={submitDisabled}
-            activeOpacity={0.8}
-          >
-            <Box
-              style={[styles.submit, submitDisabled && styles.submitDisabled]}
-            >
-              <Text variant="bodyStrong" style={styles.submitLabel}>
-                {submitLabel}
+          {options.length === 0 ? (
+            <Box alignItems="center" paddingVertical="sm">
+              <Text variant="bodySmDefault" color="gray400">
+                No options to rank yet.
               </Text>
             </Box>
-          </TouchableOpacity>
+          ) : (
+            options.map((opt, i) => (
+              <DraggableRow
+                key={opt.id}
+                option={opt}
+                rank={i + 1}
+                isDragging={draggingId === opt.id}
+                translateY={translateY}
+                gesture={makeGesture(opt.id, i)}
+                closed={closed}
+              />
+            ))
+          )}
+        </Box>
+
+        {/* Pitch button or Submit */}
+        <Box
+          alignItems="flex-end"
+          flexDirection="row"
+          justifyContent="flex-end"
+          gap="sm"
+        >
+          {options.length === 0 ? (
+            <Button
+              label="Create pitch"
+              layout="textOnly"
+              variant="Secondary"
+              onPress={() => router.push(`/trips/${tripId}/pitches` as any)}
+              style={{ minWidth: 0, paddingHorizontal: 12 }}
+            />
+          ) : tripPitchDeadline &&
+            poll.deadline &&
+            new Date(tripPitchDeadline).getTime() ===
+              new Date(poll.deadline).getTime() ? (
+            <Button
+              label="View pitches"
+              layout="textOnly"
+              variant="Secondary"
+              onPress={() => router.push(`/trips/${tripId}/pitches` as any)}
+              style={{ minWidth: 0, paddingHorizontal: 12 }}
+            />
+          ) : (
+            <TouchableOpacity
+              onPress={handleSubmit}
+              disabled={submitDisabled}
+              activeOpacity={0.8}
+            >
+              <Box
+                style={[styles.submit, submitDisabled && styles.submitDisabled]}
+              >
+                <Text variant="bodyStrong" style={styles.submitLabel}>
+                  {submitLabel}
+                </Text>
+              </Box>
+            </TouchableOpacity>
+          )}
         </Box>
       </Box>
     </Box>

--- a/frontend/app/(app)/trips/[id]/polls/components/rank-poll-card.tsx
+++ b/frontend/app/(app)/trips/[id]/polls/components/rank-poll-card.tsx
@@ -276,7 +276,10 @@ export default function RankPollCard({
     <Box backgroundColor="white" borderRadius="md" style={styles.card}>
       <Box style={styles.inner}>
         {/* Header */}
-        <Pressable onPress={onPress} disabled={!onPress || previewMode}>
+        <Pressable
+          onPress={onPress}
+          disabled={!onPress || poll.all_options?.length === 0 || previewMode}
+        >
           <Box gap="xxs">
             <Box flexDirection="row" alignItems="flex-start" gap="xs">
               <Text


### PR DESCRIPTION
- **empty pitch**
- **disable**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-visible changes

- Updated "Pitch" action in FAB menu to navigate to trip pitches index route instead of creation route
- Rank poll card displays "No options to rank yet" message when ranking options are empty
- Rank poll card header is disabled when there are no options available
- Conditional button logic in rank poll card: shows "Create pitch" when empty, "View pitches" when deadline matches, or "Submit" otherwise

## Categorized changes

**Fixes**
- Rank poll card: disabled header Pressable when `poll.all_options?.length === 0`
- Rank poll card: disabled submit state handling for empty options
- FAB menu: corrected "Pitch" action routing

**Improvements**
- Rank poll card: explicit empty state messaging instead of rendering nothing
- Rank poll card: conditional pitch button based on poll state and deadline
- Rank poll card: added trip pitch deadline awareness to UI behavior

## Contribution summary

| Component | Added | Removed |
|-----------|-------|---------|
| create-fab.tsx | 1 | 1 |
| rank-poll-card.tsx | 67 | 28 |
| **Total** | **68** | **29** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->