### PR TITLE
chore: Fix bottom sheet + modal keyboard behavior

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -43,6 +43,7 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
+      "softwareKeyboardLayoutMode": "resize",
       "predictiveBackGestureEnabled": false,
       "permissions": [
         "RECEIVE_BOOT_COMPLETED",

--- a/frontend/app/(app)/components/join-or-create-trip-sheet.tsx
+++ b/frontend/app/(app)/components/join-or-create-trip-sheet.tsx
@@ -1,6 +1,7 @@
 import { BottomSheet, Box, Button, Divider, Text } from "@/design-system";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import { X } from "lucide-react-native";
 import { useRef, useState } from "react";
 import { StyleSheet, TextInput, TouchableOpacity } from "react-native";
@@ -79,9 +80,9 @@ function TripCodeInput({ value, onChange }: TripCodeInputProps) {
           alignItems="center"
           style={styles.codeCell}
         >
-          <TextInput
+          <BottomSheetTextInput
             ref={(ref) => {
-              inputRefs.current[index] = ref;
+              inputRefs.current[index] = (ref as TextInput | null) ?? null;
             }}
             value={char}
             onChangeText={(text) => handleChange(text, index)}

--- a/frontend/app/(app)/settings/accounts/index.tsx
+++ b/frontend/app/(app)/settings/accounts/index.tsx
@@ -14,12 +14,12 @@ import { Layout } from "@/design-system/tokens/layout";
 import { router, Stack } from "expo-router";
 import { useEffect, useState } from "react";
 import {
-  KeyboardAvoidingView,
   Platform,
   ScrollView,
   StyleSheet,
   TouchableOpacity,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 // ─── Sub-components ───────────────────────────────────────────────────────────

--- a/frontend/app/(app)/trips/[id]/activities/components/add-activity-manual-sheet.tsx
+++ b/frontend/app/(app)/trips/[id]/activities/components/add-activity-manual-sheet.tsx
@@ -10,6 +10,7 @@ import type {
   ModelsParsedActivityData,
 } from "@/types/types.gen";
 import { locationSelectStore } from "@/utilities/locationSelectStore";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import { router } from "expo-router";
 import { Calendar, DollarSign, Link, MapPin } from "lucide-react-native";
 import {
@@ -19,7 +20,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { Pressable, StyleSheet, TextInput, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import {
   AddItemManualSheet,
   type AddItemManualSheetHandle,
@@ -255,7 +256,7 @@ export const AddActivityManualSheet = forwardRef<
                 size={16}
                 color={link ? ColorPalette.gray700 : ColorPalette.blue500}
               />
-              <TextInput
+              <BottomSheetTextInput
                 value={link}
                 onChangeText={setLink}
                 placeholder="Add link"

--- a/frontend/app/(app)/trips/[id]/components/add-item-manual-sheet.tsx
+++ b/frontend/app/(app)/trips/[id]/components/add-item-manual-sheet.tsx
@@ -7,6 +7,7 @@ import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
 import { FontFamily } from "@/design-system/tokens/typography";
 import { getImageURL } from "@/services/imageService";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import * as ExpoImagePicker from "expo-image-picker";
 import { ImagePlus, X } from "lucide-react-native";
 import {
@@ -16,13 +17,7 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  Image,
-  Pressable,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-} from "react-native";
+import { Image, Pressable, StyleSheet, TouchableOpacity } from "react-native";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -228,14 +223,14 @@ function AddItemManualSheetInner<T>(
 
           {/* Name + description */}
           <Box style={styles.nameSection}>
-            <TextInput
+            <BottomSheetTextInput
               value={name}
               onChangeText={setName}
               placeholder={namePlaceholder}
               placeholderTextColor={ColorPalette.gray400}
               style={styles.nameInput}
             />
-            <TextInput
+            <BottomSheetTextInput
               value={description}
               onChangeText={setDescription}
               placeholder="Add a description"

--- a/frontend/app/(app)/trips/[id]/components/entity-detail-screen.tsx
+++ b/frontend/app/(app)/trips/[id]/components/entity-detail-screen.tsx
@@ -14,6 +14,7 @@ import { ColorPalette } from "@/design-system/tokens/color";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
 import { FontFamily, FontSize } from "@/design-system/tokens/typography";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import type { BottomSheetMethods } from "@gorhom/bottom-sheet/lib/typescript/types";
 import {
   Camera,
@@ -172,10 +173,13 @@ export function EntityDetailScreen({
   const [linkDraft, setLinkDraft] = useState("");
 
   const linkEditSheetRef = useRef<BottomSheetMethods>(null);
+  const linkInputRef = useRef<TextInput>(null);
 
   useEffect(() => {
     if (isEditingLink) {
       linkEditSheetRef.current?.snapToIndex(0);
+      const focusTimeout = setTimeout(() => linkInputRef.current?.focus(), 250);
+      return () => clearTimeout(focusTimeout);
     } else {
       linkEditSheetRef.current?.close();
     }
@@ -420,7 +424,8 @@ export function EntityDetailScreen({
       >
         <Box style={styles.linkEditSheet}>
           <Text style={styles.linkEditTitle}>Edit link</Text>
-          <TextInput
+          <BottomSheetTextInput
+            ref={linkInputRef as unknown as React.Ref<any>}
             value={linkDraft}
             onChangeText={setLinkDraft}
             placeholder="https://"
@@ -428,7 +433,6 @@ export function EntityDetailScreen({
             style={styles.linkEditInput}
             autoCapitalize="none"
             keyboardType="url"
-            autoFocus
           />
           <Pressable
             style={styles.linkEditSave}

--- a/frontend/app/(app)/trips/[id]/housing/components/add-housing-manual-sheet.tsx
+++ b/frontend/app/(app)/trips/[id]/housing/components/add-housing-manual-sheet.tsx
@@ -10,6 +10,7 @@ import type {
   ModelsParsedActivityData,
 } from "@/types/types.gen";
 import { locationSelectStore } from "@/utilities/locationSelectStore";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import { router } from "expo-router";
 import { Calendar, DollarSign, Link, MapPin } from "lucide-react-native";
 import {
@@ -19,7 +20,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { Pressable, StyleSheet, TextInput, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import {
   AddItemManualSheet,
   type AddItemManualSheetHandle,
@@ -254,7 +255,7 @@ export const AddHousingManualSheet = forwardRef<
                 size={16}
                 color={link ? ColorPalette.gray700 : ColorPalette.blue500}
               />
-              <TextInput
+              <BottomSheetTextInput
                 value={link}
                 onChangeText={setLink}
                 placeholder="Add link"

--- a/frontend/app/(app)/trips/[id]/pitches/creation/components/create-pitch-form-sheet.tsx
+++ b/frontend/app/(app)/trips/[id]/pitches/creation/components/create-pitch-form-sheet.tsx
@@ -2,11 +2,12 @@ import { Box, Button, Divider, Text } from "@/design-system";
 import BottomSheetComponent from "@/design-system/components/bottom-sheet/bottom-sheet";
 import { ColorPalette } from "@/design-system/tokens/color";
 import { Typography } from "@/design-system/tokens/typography";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import { BottomSheetMethods } from "@gorhom/bottom-sheet/lib/typescript/types";
 import { Image } from "expo-image";
 import { ImagePlus, Link, Mic, X } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
-import { Pressable, StyleSheet, TextInput } from "react-native";
+import { Pressable, StyleSheet } from "react-native";
 import { PitchContentSections } from "../../components/pitch-content-sections";
 import type { RecordingResult } from "./audio-pitch-sheet";
 
@@ -207,7 +208,7 @@ export function CreatePitchFormSheet({
             </Box>
           </Pressable>
 
-          <TextInput
+          <BottomSheetTextInput
             value={descriptionValue}
             onChangeText={(value) => {
               setDescriptionValue(value);

--- a/frontend/app/(auth)/components/complete-profile-form.tsx
+++ b/frontend/app/(auth)/components/complete-profile-form.tsx
@@ -5,10 +5,10 @@ import { useUserStore } from "@/auth/store";
 import { Box, Button, Text } from "@/design-system";
 import { getDeviceTimeZone } from "@/utilities/timezone";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { TextInput } from "react-native";
 import { z } from "zod";
 
 const PROFILE_SCHEMA = z.object({
@@ -138,7 +138,7 @@ export default function CompleteProfileForm({
               padding="sm"
               backgroundColor="white"
             >
-              <TextInput
+              <BottomSheetTextInput
                 placeholder="John Doe"
                 value={value}
                 onChangeText={onChange}
@@ -172,7 +172,7 @@ export default function CompleteProfileForm({
               padding="sm"
               backgroundColor="white"
             >
-              <TextInput
+              <BottomSheetTextInput
                 placeholder="john_doe"
                 value={value}
                 onChangeText={onChange}

--- a/frontend/app/(auth)/components/login-form.tsx
+++ b/frontend/app/(auth)/components/login-form.tsx
@@ -8,11 +8,11 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   Keyboard,
-  KeyboardAvoidingView,
   Platform,
   Pressable,
   TouchableWithoutFeedback,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { CountryCode } from "react-native-country-picker-modal";
 import { z } from "zod";
 import CountryPickerSheet, { CountryItem } from "./country-picker-sheet";

--- a/frontend/app/(auth)/components/verify-form.tsx
+++ b/frontend/app/(auth)/components/verify-form.tsx
@@ -7,11 +7,11 @@ import { useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   Keyboard,
-  KeyboardAvoidingView,
   Platform,
   TextInput,
   TouchableWithoutFeedback,
 } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { z } from "zod";
 
 const OTP_LENGTH = 6;

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -10,6 +10,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useMemo } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 
 SplashScreen.preventAutoHideAsync();
@@ -43,22 +44,24 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaProvider>
-        <ThemeProvider theme={theme}>
-          <QueryClientProvider client={queryClient}>
-            <UserProvider>
-              <NotificationProvider>
-                <ToastProvider>
-                  <PortalProvider>
-                    <StatusBar style="auto" />
-                    <Slot />
-                  </PortalProvider>
-                </ToastProvider>
-              </NotificationProvider>
-            </UserProvider>
-          </QueryClientProvider>
-        </ThemeProvider>
-      </SafeAreaProvider>
+      <KeyboardProvider>
+        <SafeAreaProvider>
+          <ThemeProvider theme={theme}>
+            <QueryClientProvider client={queryClient}>
+              <UserProvider>
+                <NotificationProvider>
+                  <ToastProvider>
+                    <PortalProvider>
+                      <StatusBar style="auto" />
+                      <Slot />
+                    </PortalProvider>
+                  </ToastProvider>
+                </NotificationProvider>
+              </UserProvider>
+            </QueryClientProvider>
+          </ThemeProvider>
+        </SafeAreaProvider>
+      </KeyboardProvider>
     </GestureHandlerRootView>
   );
 }

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -40,6 +40,7 @@
         "react-native": "0.81.5",
         "react-native-country-picker-modal": "^2.0.0",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-keyboard-controller": "^1.21.5",
         "react-native-localize": "^3.7.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -2061,6 +2062,8 @@
     "react-native-gesture-handler": ["react-native-gesture-handler@2.28.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.2.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q=="],
+
+    "react-native-keyboard-controller": ["react-native-keyboard-controller@1.21.5", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-reanimated": ">=3.0.0" } }, "sha512-wxR+vpJ+2g6QMQCP1mRQKySDUietf5xLntZ76cUNHOGsjyqk6LtznXwHBG9YsR9E/b2IrHXISylwqPnIit6Y6A=="],
 
     "react-native-localize": ["react-native-localize@3.7.0", "", { "peerDependencies": { "@expo/config-plugins": "*", "react": "*", "react-native": "*", "react-native-macos": "*" }, "optionalPeers": ["@expo/config-plugins", "react-native-macos"] }, "sha512-6Ohx+zZzycC6zhNVBGM/u1U+O6Ww29YIFseeyXqsKcO/pTfjLcdE40IUJF4SVVwrdh00IMJwy90HjLGUaeqK7Q=="],
 

--- a/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
+++ b/frontend/design-system/components/bottom-sheet/bottom-sheet.tsx
@@ -12,11 +12,10 @@ import React, {
   createContext,
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useRef,
 } from "react";
-import { Dimensions, Keyboard, Platform } from "react-native";
+import { Dimensions, Keyboard } from "react-native";
 import { CornerRadius } from "../../tokens/corner-radius";
 import { Layout } from "../../tokens/layout";
 
@@ -85,17 +84,6 @@ const BottomSheetModal = forwardRef<Ref, BottomSheetModalProps>(
       },
       [onChange],
     );
-
-    useEffect(() => {
-      const event =
-        Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
-      const subscription = Keyboard.addListener(event, () => {
-        if (currentIndex.current >= 0) {
-          innerRef.current?.snapToIndex(currentIndex.current);
-        }
-      });
-      return () => subscription.remove();
-    }, []);
 
     const renderBackdrop = useCallback(
       (props: BottomSheetBackdropProps) =>

--- a/frontend/design-system/components/high-order/screen.tsx
+++ b/frontend/design-system/components/high-order/screen.tsx
@@ -1,4 +1,5 @@
-import { Keyboard, KeyboardAvoidingView, Platform, View } from "react-native";
+import { Keyboard, Platform, View } from "react-native";
+import { KeyboardAvoidingView } from "react-native-keyboard-controller";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 
 type ScreenProps = {
@@ -16,7 +17,7 @@ export function Screen({
     <SafeAreaView style={{ flex: 1, backgroundColor }} edges={edges}>
       <KeyboardAvoidingView
         style={{ flex: 1 }}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
         <View
           style={{ flex: 1 }}

--- a/frontend/design-system/components/inputs/text-field.tsx
+++ b/frontend/design-system/components/inputs/text-field.tsx
@@ -5,8 +5,10 @@ import { CoreSize } from "@/design-system/tokens/core-size";
 import { CornerRadius } from "@/design-system/tokens/corner-radius";
 import { Layout } from "@/design-system/tokens/layout";
 import { FontFamily } from "@/design-system/tokens/typography";
-import React, { useState } from "react";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
+import React, { useContext, useState } from "react";
 import { StyleSheet, TextInput, TextInputProps } from "react-native";
+import { InsideBottomSheetContext } from "../bottom-sheet/bottom-sheet";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -54,6 +56,8 @@ export default function TextField({
   const [focused, setFocused] = useState(false);
   const hasValue = value.trim().length > 0;
   const isActive = focused || (highlightWhenFilled && hasValue);
+  const isInsideBottomSheet = useContext(InsideBottomSheetContext);
+  const Input = isInsideBottomSheet ? BottomSheetTextInput : TextInput;
 
   return (
     <Box style={styles.container}>
@@ -72,7 +76,7 @@ export default function TextField({
         ]}
       >
         {leftIcon && <Box style={styles.iconWrapper}>{leftIcon}</Box>}
-        <TextInput
+        <Input
           style={[styles.input, disabled && styles.inputDisabled]}
           value={value}
           onChangeText={onChangeText}

--- a/frontend/design-system/primitives/price-picker.tsx
+++ b/frontend/design-system/primitives/price-picker.tsx
@@ -1,12 +1,11 @@
 import { BottomSheet, Box, Button, Text } from "@/design-system";
 import { ColorPalette } from "@/design-system/tokens/color";
+import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import type { BottomSheetMethods } from "@gorhom/bottom-sheet/lib/typescript/types";
 import { X } from "lucide-react-native";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Animated,
-  KeyboardAvoidingView,
-  Platform,
   Pressable,
   StyleSheet,
   TextInput,
@@ -98,6 +97,8 @@ export function PricePicker({
       currentOffset.current = offset;
       baseOffset.current = offset;
       sheetRef.current?.snapToIndex(0);
+      const focusTimeout = setTimeout(() => inputRef.current?.focus(), 250);
+      return () => clearTimeout(focusTimeout);
     } else {
       sheetRef.current?.close();
     }
@@ -171,16 +172,14 @@ export function PricePicker({
   return (
     <BottomSheet
       ref={sheetRef}
-      snapPoints={[270]}
+      snapPoints={[270, "80%"]}
       initialIndex={-1}
+      disableScrollView
       onChange={(index) => {
         if (index < 0) onClose();
       }}
     >
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        style={styles.sheet}
-      >
+      <View style={styles.sheet}>
         {/* Header */}
         <Box style={styles.header}>
           <Text variant="bodyMedium" color="gray950">
@@ -194,8 +193,8 @@ export function PricePicker({
         {/* Editable price */}
         <View style={styles.priceRow}>
           <Text style={styles.dollarSign}>$</Text>
-          <TextInput
-            ref={inputRef}
+          <BottomSheetTextInput
+            ref={inputRef as unknown as React.Ref<any>}
             value={rawText}
             onChangeText={handleTextChange}
             keyboardType="decimal-pad"
@@ -204,7 +203,6 @@ export function PricePicker({
             style={styles.priceInput}
             maxLength={7}
             selectTextOnFocus
-            autoFocus
           />
         </View>
 
@@ -223,7 +221,7 @@ export function PricePicker({
             onPress={handleConfirm}
           />
         </Box>
-      </KeyboardAvoidingView>
+      </View>
     </BottomSheet>
   );
 }

--- a/frontend/design-system/primitives/price-picker.tsx
+++ b/frontend/design-system/primitives/price-picker.tsx
@@ -4,13 +4,7 @@ import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import type { BottomSheetMethods } from "@gorhom/bottom-sheet/lib/typescript/types";
 import { X } from "lucide-react-native";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  Animated,
-  Pressable,
-  StyleSheet,
-  TextInput,
-  View,
-} from "react-native";
+import { Animated, Pressable, StyleSheet, TextInput, View } from "react-native";
 import { FontFamily, FontSize } from "../tokens/typography";
 
 // ─── Constants ───────────────────────────────────────────────────────────────

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "react-native": "0.81.5",
     "react-native-country-picker-modal": "^2.0.0",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-keyboard-controller": "^1.21.5",
     "react-native-localize": "^3.7.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
# Description

<!--  
Summarize the change or issue being fixed, including relevant context.  
Outline the high-level approach, how it fits into the system, and key design decisions or trade-offs.  
-->
- add fixes to push everything up when keyboard opens

## How has this been tested?
<!--
For frontend changes, consider adding a screenshot or short recording.
For backend changes, consider adding tests.
-->

## Checklist

* [x]  I have self-reviewed my code for readability, maintainability, performance, and added comments/documentation where necessary.
* [x] New and existing tests pass locally with my changes.
* [x] I have followed the project's coding standards and best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-Visible Changes

- Text inputs within bottom sheets and modals now properly push UI content upward when the keyboard appears, preventing content from being obscured
- Android software keyboard layout automatically resizes the app view instead of covering content via `softwareKeyboardLayoutMode: "resize"` configuration
- Text input focus management now uses explicit delayed focus (250ms) in bottom sheet contexts for improved UX
- Keyboard event handling is centralized through a top-level KeyboardProvider wrapping the entire app

## Changes by Category

**Fixes**
- Removed conflicting keyboard hide listener that was re-snapping bottom sheets after keyboard dismissal
- Android keyboard layout: added `softwareKeyboardLayoutMode: "resize"` to prevent input overlap
- Standardized text input behavior across auth and bottom sheet flows

**Improvements**
- Migrated 7 form/input components to BottomSheetTextInput: join-or-create trip code input, complete profile form (name/username), activity link, item details (name/description), housing link, pitch description, and price picker
- Enhanced TextField component with dynamic bottom-sheet context awareness via InsideBottomSheetContext
- Upgraded KeyboardAvoidingView to `react-native-keyboard-controller` in 4 locations (login, verify, accounts screens, plus design-system screen wrapper) for superior keyboard event handling
- Updated price-picker snap points and removed KeyboardAvoidingView wrapper for simplified layout

**Infra**
- Added `react-native-keyboard-controller` v1.21.5 dependency
- Wrapped root layout with KeyboardProvider from react-native-keyboard-controller

## Author Contribution

| Category | Added | Removed | Net |
|----------|-------|---------|-----|
| Component Updates | 40 | 33 | +7 |
| Layout/Root Changes | 19 | 16 | +3 |
| Config (app.json) | 1 | 0 | +1 |
| Package Manifest | 1 | 0 | +1 |
| **Total** | **61** | **49** | **+12** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->